### PR TITLE
fix mention in ban message if user has no username

### DIFF
--- a/app/events/telegram.go
+++ b/app/events/telegram.go
@@ -98,7 +98,13 @@ func (l *TelegramListener) Do(ctx context.Context) (err error) {
 			// check for ban
 			if b := l.check(msg.From); b.active {
 				if b.new {
-					m := fmt.Sprintf("@%s _тебя слишком много, отдохни..._", msg.From.Username)
+					var mention string
+					if msg.From.Username == "" {
+						mention = fmt.Sprintf("[%s](tg://user?id=%d)", msg.From.DisplayName, update.Message.From.ID)
+					} else {
+						mention = "@" + msg.From.Username
+					}
+					m := fmt.Sprintf("%s _тебя слишком много, отдохни..._", mention)
 					tbMsg := tbapi.NewMessage(update.Message.Chat.ID, m)
 					tbMsg.ParseMode = tbapi.ModeMarkdown
 					if res, err := l.botAPI.Send(tbMsg); err != nil {


### PR DESCRIPTION
If bot bans a user and they have no username set, bot will use an empty string as a mention, which does not make sense.

Example (no fix):
```
@ тебя слишком много, отдохни...
```

Telegram allows to mention such users by their ID (example in markdown):
```markdown
[anyString](tg://user?id=userId)
```

Example (fix):
```
Senpos тебя слишком много, отдохни...
```

Notice: `Senpos` is clickable and Telegram clients open user profile if you click on it