### PR TITLE
Бот не должен банить за старые сообщения

### DIFF
--- a/app/events/telegram.go
+++ b/app/events/telegram.go
@@ -95,7 +95,7 @@ func (l *TelegramListener) Do(ctx context.Context) (err error) {
 			log.Printf("[DEBUG] incoming msg: %+v", msg)
 
 			// check for ban
-			if b := l.check(msg.From); b.active {
+			if b := l.check(msg.From, msg.Sent); b.active {
 				if b.new {
 					mention := "@" + msg.From.Username
 					if msg.From.Username == "" {

--- a/app/events/terminator.go
+++ b/app/events/terminator.go
@@ -27,7 +27,7 @@ type ban struct {
 }
 
 // check if user bothered bot too often and ban for BanDuration
-func (t *Terminator) check(user bot.User) ban {
+func (t *Terminator) check(user bot.User, sent time.Time) ban {
 
 	noBan := ban{active: false, new: false}
 	if t.Exclude.IsSuper(user.Username) {
@@ -41,7 +41,7 @@ func (t *Terminator) check(user bot.User) ban {
 
 	info, found := t.users[user]
 	if !found {
-		t.users[user] = activity{lastActivity: time.Now()}
+		t.users[user] = activity{lastActivity: sent}
 		return noBan
 	}
 
@@ -70,7 +70,7 @@ func (t *Terminator) check(user bot.User) ban {
 		info.penalty = 0
 	}
 
-	info.lastActivity = time.Now()
+	info.lastActivity = sent
 	t.users[user] = info
 	return noBan
 }

--- a/app/events/terminator_test.go
+++ b/app/events/terminator_test.go
@@ -17,27 +17,27 @@ func TestTerminator_checkTerminate(t *testing.T) {
 	}
 
 	// trigger ban
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now()))
 	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now()))
 	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now()))
 
 	// banned
-	assert.Equal(t, ban{active: true, new: true}, term.check(bot.User{Username: "user"}))
+	assert.Equal(t, ban{active: true, new: true}, term.check(bot.User{Username: "user"}, time.Now()))
 	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, ban{active: true, new: false}, term.check(bot.User{Username: "user"}))
+	assert.Equal(t, ban{active: true, new: false}, term.check(bot.User{Username: "user"}, time.Now()))
 
 	// ban expired
 	time.Sleep(510 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now()))
 
 	// trigger ban again
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now()))
 	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now()))
 	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, ban{active: true, new: true}, term.check(bot.User{Username: "user"}))
+	assert.Equal(t, ban{active: true, new: true}, term.check(bot.User{Username: "user"}, time.Now()))
 }
 
 func TestTerminator_checkAdmin(t *testing.T) {
@@ -49,12 +49,12 @@ func TestTerminator_checkAdmin(t *testing.T) {
 	}
 
 	// try to trigger ban
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "umputun"}))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "umputun"}, time.Now()))
 	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "umputun"}))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "umputun"}, time.Now()))
 	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "umputun"}))
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "umputun"}))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "umputun"}, time.Now()))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "umputun"}, time.Now()))
 }
 
 func TestTerminator_checkOk(t *testing.T) {
@@ -66,13 +66,32 @@ func TestTerminator_checkOk(t *testing.T) {
 	}
 
 	// trigger ban
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}))
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}))
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now()))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now()))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now()))
 	time.Sleep(51 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now()))
 	time.Sleep(51 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now()))
 	time.Sleep(51 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now()))
+}
+
+func TestTerminator_ignoreOldMessages(t *testing.T) {
+	term := Terminator{
+		BanDuration:   500 * time.Millisecond,
+		BanPenalty:    2,
+		AllowedPeriod: 10 * time.Millisecond,
+	}
+
+	// ignore old messages
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-12*time.Millisecond)))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-11*time.Millisecond)))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-10*time.Millisecond)))
+
+	// handle messages that entered "allowed period" window
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-9*time.Millisecond))) // penalty = 0
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-8*time.Millisecond))) // penalty = 1
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-7*time.Millisecond))) // penalty = 2
+	assert.Equal(t, ban{active: true, new: true}, term.check(bot.User{Username: "user"}, time.Now().Add(-6*time.Millisecond)))   // ban
 }


### PR DESCRIPTION
Если бот отсутствует какое-то время и его снова запускают – Телеграм отправит все сообщения которые были в группе за время отсутствия бота, что приводит к массовому бану пользователей, так как бот считает что они все были отправлены "сейчас".

Этот PR исправляет такое поведение и не банит пользователей за старые сообщения.