### PR TITLE
Reporter: mention ≠ link, handle links w/o schema

### DIFF
--- a/app/reporter/export.go
+++ b/app/reporter/export.go
@@ -8,6 +8,7 @@ import (
 	"html"
 	"html/template"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -292,7 +293,7 @@ func filter(msg bot.Message) bool {
 
 func format(text string, entities *[]bot.Entity) template.HTML {
 	if entities == nil {
-		return template.HTML(html.EscapeString(text)) // nolint
+		return template.HTML(strings.ReplaceAll(html.EscapeString(text), "\n", "<br>")) // nolint
 	}
 
 	runes := []rune(text)
@@ -346,10 +347,22 @@ func getDecoration(entity bot.Entity, body []rune) (string, string) {
 		return fmt.Sprintf("<a href=\"%s\">", entity.URL), "</a>"
 
 	case "url":
-		return fmt.Sprintf("<a href=\"%s\">", string(body)), "</a>"
+		urlRaw := string(body)
+
+		// fix links without scheme so they will be non-relative in browser
+		u, err := url.Parse(urlRaw)
+		if err != nil {
+			log.Printf("[ERROR] failed parse URL %s", urlRaw)
+		}
+		if u.Scheme == "" {
+			u.Scheme = "https"
+			urlRaw = u.String()
+		}
+
+		return fmt.Sprintf("<a href=\"%s\">", urlRaw), "</a>"
 
 	case "mention":
-		return fmt.Sprintf("<a href=\"https://t.me/%s\">", string(body[1:])), "</a>"
+		return fmt.Sprintf("<a class=\"mention\" href=\"https://t.me/%s\">", string(body[1:])), "</a>"
 		// body[1:] because first symbol in mention is "@" it's not needed for link
 
 	case "email":

--- a/app/reporter/export.go
+++ b/app/reporter/export.go
@@ -353,10 +353,11 @@ func getDecoration(entity bot.Entity, body []rune) (string, string) {
 		u, err := url.Parse(urlRaw)
 		if err != nil {
 			log.Printf("[ERROR] failed parse URL %s", urlRaw)
-		}
-		if u.Scheme == "" {
-			u.Scheme = "https"
-			urlRaw = u.String()
+		} else {
+			if u.Scheme == "" {
+				u.Scheme = "https"
+				urlRaw = u.String()
+			}
 		}
 
 		return fmt.Sprintf("<a href=\"%s\">", urlRaw), "</a>"

--- a/app/reporter/export_test.go
+++ b/app/reporter/export_test.go
@@ -334,6 +334,11 @@ func TestExporter_format(t *testing.T) {
 			"<strong>text</strong>",
 		},
 		{
+			"- У нас дыра в безопасности\n- Ну хоть что-то у нас в безопасности",
+			nil,
+			"- У нас дыра в безопасности<br>- Ну хоть что-то у нас в безопасности",
+		},
+		{
 			"some text here",
 			&[]bot.Entity{{Type: "italic", Offset: 5, Length: 4}},
 			"some <em>text</em> here",
@@ -341,7 +346,12 @@ func TestExporter_format(t *testing.T) {
 		{
 			"@chuhlomin тебя слишком много, отдохни...",
 			&[]bot.Entity{{Type: "mention", Offset: 0, Length: 10}, {Type: "italic", Offset: 11, Length: 30}},
-			"<a href=\"https://t.me/chuhlomin\">@chuhlomin</a> <em>тебя слишком много, отдохни...</em>",
+			"<a class=\"mention\" href=\"https://t.me/chuhlomin\">@chuhlomin</a> <em>тебя слишком много, отдохни...</em>",
+		},
+		{
+			"Меня url заинтересовал... do.co",
+			&[]bot.Entity{{Type: "url", Offset: 26, Length: 5}},
+			"Меня url заинтересовал... <a href=\"https://do.co\">do.co</a>",
 		},
 		{
 			"inline",

--- a/data/logs.html
+++ b/data/logs.html
@@ -106,7 +106,18 @@
                         value: 0,
                         classname: 'link',
                         style: '.table tr { display: none; } .table tr.link { display: table-row; }',
-                        detect: function(row) { return row.getElementsByTagName('a').length > 0; }
+                        detect: function(row) {
+                            let links = row.getElementsByTagName('a');
+                            if (links.length == 0) {
+                                return false;
+                            }
+                            for (i = 0; i < links.length; i++) {
+                                if (!links[i].classList.contains("mention")) {
+                                    return true
+                                }
+                            }
+                            return false;
+                        }
                     },
                     bot: {
                         value: 0,

--- a/data/logs.html
+++ b/data/logs.html
@@ -108,10 +108,7 @@
                         style: '.table tr { display: none; } .table tr.link { display: table-row; }',
                         detect: function(row) {
                             let links = row.getElementsByTagName('a');
-                            if (links.length == 0) {
-                                return false;
-                            }
-                            for (i = 0; i < links.length; i++) {
+                            for (let i = 0; i < links.length; i++) {
                                 if (!links[i].classList.contains("mention")) {
                                     return true
                                 }


### PR DESCRIPTION
Свежие мелкие исправления по сегодняшнему логу:
* переносы строк теперь работают в сообщениях и без форматирования
* добавляется "https://" к ссылкам без схемы (do.co), чтобы она не вела себя как относительная в браузере
* фильтр "оставить сообщения со ссылками" теперь игнорирует упоминания пользователей (ссылки типа `https://t.me/`)