### PR TITLE
Reporter: определять сообщения "в эфире" по подстроке в сообщении бота

### DIFF
--- a/app/reporter/export.go
+++ b/app/reporter/export.go
@@ -244,14 +244,15 @@ func readMessages(path string, broadcastUsers SuperUser) ([]bot.Message, error) 
 
 		if broadcastUsers != nil && broadcastUsers.IsSuper(msg.From.Username) {
 			// if received message from bot/user who can send "broadcast" messages
-			switch msg.Text {
-			case bot.MsgBroadcastStarted:
+			if strings.Contains(msg.Text, bot.MsgBroadcastStarted) {
 				if broadcastStartedIndex == 0 {
 					// record first occurrence of MsgBroadcastFinished
 					broadcastStartedIndex = currentIndex
 				}
 				continue
-			case bot.MsgBroadcastFinished:
+			}
+
+			if strings.Contains(msg.Text, bot.MsgBroadcastFinished) {
 				// record last occurrence of MsgBroadcastFinished
 				broadcastFinishedIndex = currentIndex
 				continue

--- a/app/reporter/export_test.go
+++ b/app/reporter/export_test.go
@@ -146,6 +146,19 @@ func Test_readMessagesCheckBroadcastMessages(t *testing.T) {
 		{
 			SuperUserMock{"radio-t-bot": true},
 			[]bot.Message{
+				{Text: bot.MsgBroadcastStarted + "\n_pong_", From: bot.User{Username: "radio-t-bot"}},
+				{Text: "message-1", From: bot.User{Username: "user-1"}},
+				{Text: "message-2", From: bot.User{Username: "user-2"}},
+				{Text: bot.MsgBroadcastFinished, From: bot.User{Username: "radio-t-bot"}},
+			},
+			[]bot.Message{
+				{Text: "message-1", From: bot.User{Username: "user-1"}},
+				{Text: "message-2", From: bot.User{Username: "user-2"}},
+			},
+		},
+		{
+			SuperUserMock{"radio-t-bot": true},
+			[]bot.Message{
 				{Text: "message-0", From: bot.User{Username: "user-0"}},
 				{Text: bot.MsgBroadcastStarted, From: bot.User{Username: "radio-t-bot"}},
 				{Text: "message-1", From: bot.User{Username: "user-1"}},


### PR DESCRIPTION
Сейчас при построении HTML отчета exporter ищет сообщение полностью совпадающее с константами `MsgBroadcastStarted` и `MsgBroadcastFinished`.
Иногда бот отправляет эти сообщения вместе в ответом на другие команды и получается такое:
```
Вещание началось
_pong_
```
Этот коммит изменяет поведение чтобы правильно определять начало вещания и в таком случае.