### PR TITLE
Исправляет мульти-бото-бан для #40

### DIFF
--- a/app/bot/bot_test.go
+++ b/app/bot/bot_test.go
@@ -1,0 +1,31 @@
+package bot
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnecdot_BanInterval(t *testing.T) {
+	b := MultiBot{
+		NewWTF(time.Minute, 10*time.Minute, 0.2),
+	}
+
+	lucky := 0
+	for i := 0; i < 100; i++ {
+		r := b.OnMessage(Message{Text: "wtf!", From: User{Username: "user123"}})
+		assert.True(t, r.Send)
+		if strings.Contains(r.Text, "повезло") {
+			lucky++
+			require.True(t, r.BanInterval == 0)
+		} else {
+			require.True(t, r.BanInterval > 0)
+		}
+	}
+	t.Logf("lucky hits %d", lucky)
+	assert.True(t, lucky > 0)
+	assert.True(t, lucky < 100)
+}

--- a/app/bot/wtf.go
+++ b/app/bot/wtf.go
@@ -48,7 +48,7 @@ func (w WTF) OnMessage(msg Message) (response Response) {
 
 // ReactOn keys
 func (w WTF) ReactOn() []string {
-	return []string{"wtf!"}
+	return []string{"wtf!", "wtf?"}
 }
 
 // Help returns help message

--- a/app/bot/wtf_test.go
+++ b/app/bot/wtf_test.go
@@ -33,5 +33,5 @@ func TestWTF_OnMessage(t *testing.T) {
 }
 
 func TestWTF_Help(t *testing.T) {
-	require.Equal(t, "wtf! _– если не повезет, блокирует пользователя на какое-то время_\n", (&WTF{}).Help())
+	require.Equal(t, "wtf!, wtf? _– если не повезет, блокирует пользователя на какое-то время_\n", (&WTF{}).Help())
 }

--- a/app/events/telegram.go
+++ b/app/events/telegram.go
@@ -139,9 +139,10 @@ func (l *TelegramListener) Do(ctx context.Context) (err error) {
 
 			// some bots may request direct ban for given duration
 			if resp.Send && resp.BanInterval > 0 {
-				log.Printf("[INFO] %s banned by bot", update.Message.From.UserName)
 				if err := l.banUser(resp.BanInterval, fromChat, update.Message.From.ID); err != nil {
-					log.Printf("[ERROR] can't ban %s on bot response, %v", update.Message.From.UserName, err)
+					log.Printf("[ERROR] can't ban %v on bot response, %v", msg.From, err)
+				} else {
+					log.Printf("[INFO] %v banned by bot", msg.From)
 				}
 			}
 


### PR DESCRIPTION
Проблема была в том что информация о бане не передавалась от WTF бота в Multbot, от этого пользователи уведомлялись о бане но не банились.

Если несколько ботов захотят забанить пользователя, то "сроки" не складываются, берется максимальный.