### PR TITLE
Исправляет упоминание пользователя с символом подчеркивания в нике

### DIFF
--- a/app/bot/bot.go
+++ b/app/bot/bot.go
@@ -80,7 +80,7 @@ type Image struct {
 
 // User defines user info of the Message
 type User struct {
-	ID          string `json:",omitempty"`
+	ID          int
 	Username    string
 	DisplayName string
 }

--- a/app/bot/wtf.go
+++ b/app/bot/wtf.go
@@ -35,12 +35,12 @@ func (w WTF) OnMessage(msg Message) (response Response) {
 	}
 
 	if rand.Float64() < w.luckFactor {
-		return Response{Text: fmt.Sprintf("[%s](tg://user?id=%s), на этот раз тебе повезло!", mention, msg.From.ID), Send: true}
+		return Response{Text: fmt.Sprintf("[%s](tg://user?id=%d), на этот раз тебе повезло!", mention, msg.From.ID), Send: true}
 	}
 
 	banDuration := w.minDuration + time.Second*time.Duration(rand.Int63n(int64(w.maxDuration.Seconds()-w.minDuration.Seconds())))
 	return Response{
-		Text:        fmt.Sprintf("[%s](tg://user?id=%s) получает бан на %v", mention, msg.From.ID, banDuration),
+		Text:        fmt.Sprintf("[%s](tg://user?id=%d) получает бан на %v", mention, msg.From.ID, banDuration),
 		Send:        true,
 		BanInterval: banDuration,
 	}

--- a/app/bot/wtf.go
+++ b/app/bot/wtf.go
@@ -31,16 +31,16 @@ func (w WTF) OnMessage(msg Message) (response Response) {
 
 	mention := "@" + msg.From.Username
 	if msg.From.Username == "" {
-		mention = fmt.Sprintf("[%s](tg://user?id=%s)", msg.From.DisplayName, msg.From.ID)
+		mention = msg.From.DisplayName
 	}
 
 	if rand.Float64() < w.luckFactor {
-		return Response{Text: fmt.Sprintf("%s, на этот раз тебе повезло!", mention), Send: true}
+		return Response{Text: fmt.Sprintf("[%s](tg://user?id=%s), на этот раз тебе повезло!", mention, msg.From.ID), Send: true}
 	}
 
 	banDuration := w.minDuration + time.Second*time.Duration(rand.Int63n(int64(w.maxDuration.Seconds()-w.minDuration.Seconds())))
 	return Response{
-		Text:        fmt.Sprintf("%s получает бан на %v", mention, banDuration),
+		Text:        fmt.Sprintf("[%s](tg://user?id=%s) получает бан на %v", mention, msg.From.ID, banDuration),
 		Send:        true,
 		BanInterval: banDuration,
 	}

--- a/app/events/telegram.go
+++ b/app/events/telegram.go
@@ -194,7 +194,7 @@ func (l *TelegramListener) applyBan(msg bot.Message, duration time.Duration, cha
 	m := fmt.Sprintf("[%s](tg://user?id=%d) _тебя слишком много, отдохни..._", mention, userID)
 
 	if err := l.sendBotResponse(bot.Response{Text: m, Send: true}, chatID); err != nil {
-		return errors.Wrapf(err, "failed to send ban message for %s", msg.From)
+		return errors.Wrapf(err, "failed to send ban message for %v", msg.From)
 	}
 	err := l.banUser(duration, chatID, userID)
 	return errors.Wrapf(err, "failed to ban user %v", msg.From)
@@ -279,6 +279,7 @@ func (l *TelegramListener) transform(msg *tbapi.Message) *bot.Message {
 
 	if msg.From != nil {
 		message.From = bot.User{
+			ID:          msg.From.ID,
 			Username:    msg.From.UserName,
 			DisplayName: msg.From.FirstName + " " + msg.From.LastName,
 		}

--- a/app/events/telegram.go
+++ b/app/events/telegram.go
@@ -171,7 +171,7 @@ func (l *TelegramListener) sendBotResponse(resp bot.Response, chatID int64) erro
 	tbMsg.DisableWebPagePreview = !resp.Preview
 	res, err := l.TbAPI.Send(tbMsg)
 	if err != nil {
-		return errors.Wrap(err, "can't send message to telegram")
+		return errors.Wrapf(err, "can't send message to telegram %q", resp.Text)
 	}
 
 	l.saveBotMessage(&res, chatID)
@@ -189,9 +189,9 @@ func (l *TelegramListener) sendBotResponse(resp bot.Response, chatID int64) erro
 func (l *TelegramListener) applyBan(msg bot.Message, duration time.Duration, chatID int64, userID int) error {
 	mention := "@" + msg.From.Username
 	if msg.From.Username == "" {
-		mention = fmt.Sprintf("[%s](tg://user?id=%d)", msg.From.DisplayName, userID)
+		mention = msg.From.DisplayName
 	}
-	m := fmt.Sprintf("%s _тебя слишком много, отдохни..._", mention)
+	m := fmt.Sprintf("[%s](tg://user?id=%d) _тебя слишком много, отдохни..._", mention, userID)
 
 	if err := l.sendBotResponse(bot.Response{Text: m, Send: true}, chatID); err != nil {
 		return errors.Wrapf(err, "failed to send ban message for %s", msg.From)

--- a/app/events/telegram_test.go
+++ b/app/events/telegram_test.go
@@ -288,6 +288,7 @@ func TestTelegram_transformTextMessage(t *testing.T) {
 		&bot.Message{
 			ID: 30,
 			From: bot.User{
+				ID:          100000001,
 				Username:    "username",
 				DisplayName: "First Last",
 			},
@@ -297,6 +298,7 @@ func TestTelegram_transformTextMessage(t *testing.T) {
 		l.transform(
 			&tbapi.Message{
 				From: &tbapi.User{
+					ID:        100000001,
 					UserName:  "username",
 					FirstName: "First",
 					LastName:  "Last",

--- a/app/events/telegram_test.go
+++ b/app/events/telegram_test.go
@@ -180,7 +180,7 @@ func TestTelegramListener_DoWithAutoBan(t *testing.T) {
 		Message: &tbapi.Message{
 			Chat: &tbapi.Chat{ID: 123},
 			Text: "text 123",
-			From: &tbapi.User{UserName: "user"},
+			From: &tbapi.User{UserName: "user_name", ID: 1},
 			Date: now,
 		},
 	}
@@ -200,17 +200,17 @@ func TestTelegramListener_DoWithAutoBan(t *testing.T) {
 	bots.On("OnMessage", mock.Anything).Return(bot.Response{Send: false})
 	msgLogger.On("Save", mock.MatchedBy(func(msg *bot.Message) bool {
 		t.Logf("%v", msg)
-		return msg.Text == "text 123" && msg.From.Username == "user"
+		return msg.Text == "text 123" && msg.From.Username == "user_name"
 	}))
 	msgLogger.On("Save", mock.MatchedBy(func(msg *bot.Message) bool {
 		t.Logf("%v", msg)
-		return msg.Text == "@user _тебя слишком много, отдохни..._" && msg.From.Username == "user"
+		return msg.Text == "[@user_name](tg://user?id=1) _тебя слишком много, отдохни..._" && msg.From.Username == "user_name"
 	})).Once()
 
 	tbAPI.On("Send", mock.MatchedBy(func(c tbapi.MessageConfig) bool {
 		t.Logf("send: %+v", c)
-		return c.Text == "@user _тебя слишком много, отдохни..._"
-	})).Return(tbapi.Message{Text: "@user _тебя слишком много, отдохни..._", From: &tbapi.User{UserName: "user"}}, nil).Once()
+		return c.Text == "[@user_name](tg://user?id=1) _тебя слишком много, отдохни..._"
+	})).Return(tbapi.Message{Text: "[@user_name](tg://user?id=1) _тебя слишком много, отдохни..._", From: &tbapi.User{UserName: "user_name", ID: 1}}, nil).Once()
 
 	tbAPI.On("RestrictChatMember", mock.Anything).Return(tbapi.APIResponse{Ok: true}, nil)
 	err := l.Do(ctx)

--- a/app/events/terminator.go
+++ b/app/events/terminator.go
@@ -47,23 +47,23 @@ func (t *Terminator) check(user bot.User, sent time.Time) ban {
 
 	if time.Now().Before(info.lastActivity.Add(t.AllowedPeriod)) {
 		info.penalty++
-		log.Printf("[DEBUG] penalty increased for %s to %d", user, info.penalty)
+		log.Printf("[DEBUG] penalty increased for %v to %d", user, info.penalty)
 	} else {
 		if info.penalty > 0 {
-			log.Printf("[DEBUG] penalty reset for %s from %d", user, info.penalty)
+			log.Printf("[DEBUG] penalty reset for %v from %d", user, info.penalty)
 		}
 		info.penalty = 0
 	}
 
 	if info.penalty == t.BanPenalty {
-		log.Printf("[WARN] banned %s", user)
+		log.Printf("[WARN] banned %v", user)
 		info.penalty++
 		t.users[user] = info
 		return ban{active: true, new: true}
 	}
 
 	if info.penalty >= t.BanPenalty {
-		log.Printf("[DEBUG] still banned %s", user)
+		log.Printf("[DEBUG] still banned %v", user)
 		return ban{active: true, new: false}
 	}
 


### PR DESCRIPTION
У некоторых пользователей ник содержит символ подчеркивания.

Как правило бот отправляет сообщения с `parse_mode=Markdown` 
что ведет к тому что Телеграм считает символ "_" началом курсивного начертания
 и выдает ошибку:
```
[WARN] failed to respond on update, can't send message to telegram: Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 4
```
Поэтому я завернул все упоминания пользователей в ссылки `[%s](tg://user?id=%d)`,
для этого пришлось записывать user ID в структуру `bot.User`