### PR TITLE
[WIP] fix ban user by command "ban! user"

### DIFF
--- a/app/bot/banhammer.go
+++ b/app/bot/banhammer.go
@@ -49,9 +49,8 @@ func (b *Banhammer) OnMessage(msg Message) (response Response) {
 	userID := getUserID(name, msg.Entities)
 
 	userCfg := tbapi.ChatMemberConfig{
-		ChatID:          msg.ChatID,
-		ChannelUsername: name,
-		UserID:          userID,
+		ChatID: msg.ChatID,
+		UserID: userID,
 	}
 
 	switch cmd {

--- a/app/bot/banhammer_test.go
+++ b/app/bot/banhammer_test.go
@@ -53,20 +53,56 @@ func TestBanhammer_OnMessage(t *testing.T) {
 	su.On("IsSuper", "user").Return(false).Once()
 
 	tg.On("KickChatMember", mock.MatchedBy(func(u tbapi.KickChatMemberConfig) bool {
-		return u.ChannelUsername == "user1"
+		return u.ChannelUsername == "user1" && u.ChatID == 123 && u.UserID == 111
 	})).Return(tbapi.APIResponse{}, nil)
 
 	tg.On("UnbanChatMember", mock.MatchedBy(func(u tbapi.ChatMemberConfig) bool {
 		return u.ChannelUsername == "user1"
 	})).Return(tbapi.APIResponse{}, nil)
 
-	resp := b.OnMessage(Message{Text: "ban! user1", From: User{Username: "user"}})
+	resp := b.OnMessage(Message{
+		ChatID: 123,
+		Entities: []Entity{{
+			Type: "mention",
+			User: &User{
+				ID:          111,
+				Username:    "user1",
+				DisplayName: "user1",
+			},
+		}},
+		Text: "ban! user1",
+		From: User{Username: "user"},
+	})
 	assert.Equal(t, Response{}, resp, "not admin")
 
-	resp = b.OnMessage(Message{Text: "bawwwn! user1", From: User{Username: "admin"}})
+	resp = b.OnMessage(Message{
+		ChatID: 123,
+		Entities: []Entity{{
+			Type: "mention",
+			User: &User{
+				ID:          111,
+				Username:    "user1",
+				DisplayName: "user1",
+			},
+		}},
+		Text: "bawwwn! user1",
+		From: User{Username: "admin"},
+	})
 	assert.Equal(t, Response{}, resp, "not a command")
 
-	resp = b.OnMessage(Message{Text: "ban! user1", From: User{Username: "admin"}})
+	resp = b.OnMessage(Message{
+		ChatID: 123,
+		Entities: []Entity{{
+			Type: "mention",
+			User: &User{
+				ID:          111,
+				Username:    "user1",
+				DisplayName: "user1",
+			},
+		}},
+		Text: "ban! user1",
+		From: User{Username: "admin"},
+	})
 	assert.Equal(t, Response{Text: "прощай user1", Send: true}, resp)
 
 	resp = b.OnMessage(Message{Text: "unban! user1", From: User{Username: "admin"}})

--- a/app/bot/bot.go
+++ b/app/bot/bot.go
@@ -51,13 +51,14 @@ type SuperUser interface {
 
 // Message is primary record to pass data from/to bots
 type Message struct {
+	ChatID   int64
 	ID       int
 	From     User
 	Sent     time.Time
-	HTML     string    `json:",omitempty"`
-	Text     string    `json:",omitempty"`
-	Entities *[]Entity `json:",omitempty"`
-	Image    *Image    `json:",omitempty"`
+	HTML     string   `json:",omitempty"`
+	Text     string   `json:",omitempty"`
+	Entities []Entity `json:",omitempty"`
+	Image    *Image   `json:",omitempty"`
 }
 
 // Entity represents one special entity in a text message.
@@ -76,8 +77,8 @@ type Image struct {
 	FileID   string
 	Width    int
 	Height   int
-	Caption  string    `json:",omitempty"`
-	Entities *[]Entity `json:",omitempty"`
+	Caption  string   `json:",omitempty"`
+	Entities []Entity `json:",omitempty"`
 }
 
 // User defines user info of the Message

--- a/app/events/telegram.go
+++ b/app/events/telegram.go
@@ -309,6 +309,10 @@ func (l *TelegramListener) transform(msg *tbapi.Message) *bot.Message {
 		Text: msg.Text,
 	}
 
+	if msg.Chat != nil {
+		message.ChatID = msg.Chat.ID
+	}
+
 	if msg.From != nil {
 		message.From = bot.User{
 			ID:          msg.From.ID,
@@ -336,7 +340,7 @@ func (l *TelegramListener) transform(msg *tbapi.Message) *bot.Message {
 	return &message
 }
 
-func (l *TelegramListener) transformEntities(entities *[]tbapi.MessageEntity) *[]bot.Entity {
+func (l *TelegramListener) transformEntities(entities *[]tbapi.MessageEntity) []bot.Entity {
 	if entities == nil || len(*entities) == 0 {
 		return nil
 	}
@@ -351,6 +355,7 @@ func (l *TelegramListener) transformEntities(entities *[]tbapi.MessageEntity) *[
 		}
 		if entity.User != nil {
 			e.User = &bot.User{
+				ID:          entity.User.ID,
 				Username:    entity.User.UserName,
 				DisplayName: entity.User.FirstName + " " + entity.User.LastName,
 			}
@@ -358,5 +363,5 @@ func (l *TelegramListener) transformEntities(entities *[]tbapi.MessageEntity) *[
 		result = append(result, e)
 	}
 
-	return &result
+	return result
 }

--- a/app/events/telegram_test.go
+++ b/app/events/telegram_test.go
@@ -401,7 +401,10 @@ func TestTelegram_transformTextMessage(t *testing.T) {
 				DisplayName: "First Last",
 			},
 			Sent: time.Unix(1578627415, 0),
-			Text: "Message",
+			Text: "Message @user1",
+			Entities: []bot.Entity{
+				{Type: "mention", User: &bot.User{ID: 123, Username: "user1", DisplayName: "vasya pupkin"}},
+			},
 		},
 		l.transform(
 			&tbapi.Message{
@@ -411,9 +414,12 @@ func TestTelegram_transformTextMessage(t *testing.T) {
 					FirstName: "First",
 					LastName:  "Last",
 				},
+				Entities: &[]tbapi.MessageEntity{
+					{Type: "mention", User: &tbapi.User{ID: 123, UserName: "user1", FirstName: "vasya", LastName: "pupkin"}},
+				},
 				MessageID: 30,
 				Date:      1578627415,
-				Text:      "Message",
+				Text:      "Message @user1",
 			},
 		),
 	)
@@ -430,7 +436,7 @@ func TestTelegram_transformPhoto(t *testing.T) {
 				Width:   1280,
 				Height:  597,
 				Caption: "caption",
-				Entities: &[]bot.Entity{
+				Entities: []bot.Entity{
 					{
 						Type:   "bold",
 						Offset: 0,
@@ -482,7 +488,7 @@ func TestTelegram_transformEntities(t *testing.T) {
 		&bot.Message{
 			Sent: time.Unix(1578627415, 0),
 			Text: "@username тебя слишком много, отдохни...",
-			Entities: &[]bot.Entity{
+			Entities: []bot.Entity{
 				{
 					Type:   "mention",
 					Offset: 0,


### PR DESCRIPTION
The command also requires a chatID, where the user should be banned and userID, which could be taken from message entities.

Also, I took the liberty to convert the `*[]Entity` list in message fields to just `[]Entity` as it (I suppose) makes easier to work with the slice without pointer to it