### PR TITLE
support baning channels

### DIFF
--- a/app/bot/wtf_test.go
+++ b/app/bot/wtf_test.go
@@ -50,6 +50,15 @@ func TestWTF_OnMessage(t *testing.T) {
 		require.Equal(t, min+10*time.Second+5*54*time.Hour, resp.BanInterval)
 	})
 
+	t.Run("channel, first wtf", func(t *testing.T) {
+		resp := b.OnMessage(Message{Text: "WTF!", From: User{Username: "ChannelBot", ID: 136817688}, SenderChat: SenderChat{ID: 123, UserName: "channel_with_underscores"}})
+		require.Equal(t, "@channel\\_with\\_underscores получает бан на навсегда", resp.Text)
+		require.True(t, resp.Send)
+		require.Equal(t, min+10*time.Second+59*5*time.Hour, resp.BanInterval)
+		assert.Equal(t, User{Username: "ChannelBot", ID: 136817688}, resp.User)
+		assert.Equal(t, int64(123), resp.ChannelID)
+	})
+
 	t.Run("admin, allow wtf", func(t *testing.T) {
 		resp := b.OnMessage(Message{Text: "WTF!", From: User{Username: "super"}})
 		require.Equal(t, "", resp.Text)
@@ -62,6 +71,16 @@ func TestWTF_OnMessage(t *testing.T) {
 		msg.ReplyTo.From = User{Username: "user", ID: 1, DisplayName: "User"}
 		resp := b.OnMessage(msg)
 		assert.Equal(t, "@user получает бан на 13дн 7ч 10сек", resp.Text)
+		assert.True(t, resp.Send)
+		assert.Equal(t, min+10*time.Second+5*59*time.Hour, resp.BanInterval)
+	})
+
+	t.Run("admin, reply wtf to channel", func(t *testing.T) {
+		msg := Message{Text: "WTF!", From: User{Username: "super"}}
+		msg.ReplyTo.From = User{Username: "ChannelBot", ID: 136817688}
+		msg.ReplyTo.SenderChat = SenderChat{ID: 123, UserName: "channel"}
+		resp := b.OnMessage(msg)
+		assert.Equal(t, "@channel получает бан на навсегда", resp.Text)
 		assert.True(t, resp.Send)
 		assert.Equal(t, min+10*time.Second+5*59*time.Hour, resp.BanInterval)
 	})
@@ -88,7 +107,7 @@ func TestWTF_OnMessage(t *testing.T) {
 		require.True(t, resp.Send)
 		require.Equal(t, time.Minute*77+time.Second*7, resp.BanInterval)
 	})
-	assert.Equal(t, 15, len(su.IsSuperCalls()))
+	assert.Equal(t, 19, len(su.IsSuperCalls()))
 }
 
 func TestWTF_Help(t *testing.T) {

--- a/app/events/terminator.go
+++ b/app/events/terminator.go
@@ -27,8 +27,8 @@ type ban struct {
 	new    bool
 }
 
-// check if user bothered bot too often and ban for BanDuration
-func (t *Terminator) check(user bot.User, sent time.Time, chatID int64) ban {
+// check if user\channel bothered bot too often and ban for BanDuration
+func (t *Terminator) check(user bot.User, senderChat bot.SenderChat, sent time.Time, chatID int64) ban {
 	noBan := ban{active: false, new: false}
 	if t.Exclude.IsSuper(user.Username) {
 		return noBan
@@ -37,6 +37,13 @@ func (t *Terminator) check(user bot.User, sent time.Time, chatID int64) ban {
 	if t.users == nil {
 		t.users = make(map[bot.User]map[int64]activity)
 		log.Printf("[DEBUG] terminator with BanDuration=%v, BanPenalty=%d, excluded=%v", t.BanDuration, t.BanPenalty, t.Exclude)
+	}
+
+	// This userID is a bot which means that message was sent on behalf of the channel,
+	// so we convert the user checked for bannable activity to the channel data.
+	// https://docs.python-telegram-bot.org/en/stable/telegram.constants.html#telegram.constants.FAKE_CHANNEL_ID
+	if user.ID == 136817688 {
+		user = bot.User{ID: senderChat.ID, Username: senderChat.UserName}
 	}
 
 	chatActivity, found := t.users[user]

--- a/app/events/terminator_test.go
+++ b/app/events/terminator_test.go
@@ -17,27 +17,27 @@ func TestTerminator_checkTerminate(t *testing.T) {
 	}
 
 	// trigger ban
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now(), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now(), 1))
 	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now(), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now(), 1))
 	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now(), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now(), 1))
 
 	// banned
-	assert.Equal(t, ban{active: true, new: true}, term.check(bot.User{Username: "user"}, time.Now(), 1))
+	assert.Equal(t, ban{active: true, new: true}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now(), 1))
 	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, ban{active: true, new: false}, term.check(bot.User{Username: "user"}, time.Now(), 1))
+	assert.Equal(t, ban{active: true, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now(), 1))
 
 	// ban expired
 	time.Sleep(510 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now(), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now(), 1))
 
 	// trigger ban again
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now(), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now(), 1))
 	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now(), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now(), 1))
 	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, ban{active: true, new: true}, term.check(bot.User{Username: "user"}, time.Now(), 1))
+	assert.Equal(t, ban{active: true, new: true}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now(), 1))
 }
 
 func TestTerminator_checkAdmin(t *testing.T) {
@@ -49,12 +49,12 @@ func TestTerminator_checkAdmin(t *testing.T) {
 	}
 
 	// try to trigger ban
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "umputun"}, time.Now(), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "umputun"}, bot.SenderChat{}, time.Now(), 1))
 	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "umputun"}, time.Now(), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "umputun"}, bot.SenderChat{}, time.Now(), 1))
 	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "umputun"}, time.Now(), 1))
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "umputun"}, time.Now(), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "umputun"}, bot.SenderChat{}, time.Now(), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "umputun"}, bot.SenderChat{}, time.Now(), 1))
 }
 
 func TestTerminator_checkOk(t *testing.T) {
@@ -66,15 +66,15 @@ func TestTerminator_checkOk(t *testing.T) {
 	}
 
 	// trigger ban
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now(), 1))
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now(), 1))
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now(), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now(), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now(), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now(), 1))
 	time.Sleep(51 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now(), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now(), 1))
 	time.Sleep(51 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now(), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now(), 1))
 	time.Sleep(51 * time.Millisecond)
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now(), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now(), 1))
 }
 
 func TestTerminator_ignoreOldMessages(t *testing.T) {
@@ -85,15 +85,15 @@ func TestTerminator_ignoreOldMessages(t *testing.T) {
 	}
 
 	// ignore old messages
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-12*time.Millisecond), 1))
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-11*time.Millisecond), 1))
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-10*time.Millisecond), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now().Add(-12*time.Millisecond), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now().Add(-11*time.Millisecond), 1))
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now().Add(-10*time.Millisecond), 1))
 
 	// handle messages that entered "allowed period" window
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-9*time.Millisecond), 1)) // penalty = 0
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-8*time.Millisecond), 1)) // penalty = 1
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-7*time.Millisecond), 1)) // penalty = 2
-	assert.Equal(t, ban{active: true, new: true}, term.check(bot.User{Username: "user"}, time.Now().Add(-6*time.Millisecond), 1))   // ban
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now().Add(-9*time.Millisecond), 1)) // penalty = 0
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now().Add(-8*time.Millisecond), 1)) // penalty = 1
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now().Add(-7*time.Millisecond), 1)) // penalty = 2
+	assert.Equal(t, ban{active: true, new: true}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now().Add(-6*time.Millisecond), 1))   // ban
 }
 
 func TestTerminator_banPerChat(t *testing.T) {
@@ -104,14 +104,14 @@ func TestTerminator_banPerChat(t *testing.T) {
 	}
 
 	//ban in one chat, but still active in another
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-9*time.Millisecond), -213)) // penalty = 0
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-8*time.Millisecond), -213)) // penalty = 1
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-7*time.Millisecond), -213)) // penalty = 2
-	assert.Equal(t, ban{active: true, new: true}, term.check(bot.User{Username: "user"}, time.Now().Add(-6*time.Millisecond), -213))   // ban
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now().Add(-9*time.Millisecond), -213)) // penalty = 0
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now().Add(-8*time.Millisecond), -213)) // penalty = 1
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now().Add(-7*time.Millisecond), -213)) // penalty = 2
+	assert.Equal(t, ban{active: true, new: true}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now().Add(-6*time.Millisecond), -213))   // ban
 
 	// another chat, the same user
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-9*time.Millisecond), 346)) // penalty = 1
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-8*time.Millisecond), 346)) // penalty = 2
-	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, time.Now().Add(-7*time.Millisecond), 346)) // penalty 0
-	assert.Equal(t, ban{active: true, new: true}, term.check(bot.User{Username: "user"}, time.Now().Add(-6*time.Millisecond), 346))   // ban
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now().Add(-9*time.Millisecond), 346)) // penalty = 1
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now().Add(-8*time.Millisecond), 346)) // penalty = 2
+	assert.Equal(t, ban{active: false, new: false}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now().Add(-7*time.Millisecond), 346)) // penalty 0
+	assert.Equal(t, ban{active: true, new: true}, term.check(bot.User{Username: "user"}, bot.SenderChat{}, time.Now().Add(-6*time.Millisecond), 346))   // ban
 }


### PR DESCRIPTION
Previously message from a channel in a group would be received from a service bot with ID 136817688, and to ban a channel, you need to pass its username to the ban command, which was not done.

This change starts treating channels differently so that they could be banned, forever is the only option available in the current API.

Resolves #71. It should be merged after #74 and #75 and #80.