### PR TITLE
improve logging, messages escaping, fix pinning, fix chuck! command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: test
       run: |
         cd app && go test -race -v -mod=readonly -timeout=60s -covermode=atomic -coverprofile=$GITHUB_WORKSPACE/profile.cov_tmp ./...
-        cat $GITHUB_WORKSPACE/profile.cov_tmp | grep -v "_mock.go" > $GITHUB_WORKSPACE/profile.cov
+        cat $GITHUB_WORKSPACE/profile.cov_tmp | grep -v "mock_" > $GITHUB_WORKSPACE/profile.cov
 
     - name: install golangci-lint and goveralls
       run: |

--- a/app/bot/anecdot.go
+++ b/app/bot/anecdot.go
@@ -19,7 +19,7 @@ type Anecdote struct {
 
 // NewAnecdote makes a bot for http://rzhunemogu.ru
 func NewAnecdote(client HTTPClient) *Anecdote {
-	log.Printf("[INFO] anecdote bot with https://jokesrv.rubedo.cloud/ and http://api.icndb.com/jokes/random")
+	log.Printf("[INFO] anecdote bot with https://jokesrv.rubedo.cloud/ and https://api.chucknorris.io/jokes/random")
 	c, _ := lcw.NewExpirableCache(lcw.MaxKeys(100), lcw.TTL(time.Hour))
 	return &Anecdote{client: client, categCache: c}
 }
@@ -115,20 +115,16 @@ func (a Anecdote) jokesrv(category string) (response Response) {
 
 	}
 
-	return Response{Text: strings.TrimSuffix(rr.Content, "."), Send: true}
+	return Response{Text: EscapeMarkDownV1Text(strings.TrimSuffix(rr.Content, ".")), Send: true}
 }
 
 func (a Anecdote) chuck() (response Response) {
 
 	chuckResp := struct {
-		Type  string
-		Value struct {
-			Categories []string
-			Joke       string
-		}
+		Value string
 	}{}
 
-	reqURL := "http://api.icndb.com/jokes/random"
+	reqURL := "https://api.chucknorris.io/jokes/random"
 	req, err := makeHTTPRequest(reqURL)
 	if err != nil {
 		log.Printf("[WARN] failed to make request %s, error=%v", reqURL, err)
@@ -146,7 +142,7 @@ func (a Anecdote) chuck() (response Response) {
 		return Response{}
 	}
 	return Response{
-		Text: "- " + strings.Replace(chuckResp.Value.Joke, "&quot;", "\"", -1),
+		Text: EscapeMarkDownV1Text(chuckResp.Value),
 		Send: true,
 	}
 }

--- a/app/bot/anecdot_test.go
+++ b/app/bot/anecdot_test.go
@@ -29,7 +29,7 @@ func TestAnecdot_Help(t *testing.T) {
 ]`))}, nil
 	}}
 	a := NewAnecdote(mockHTTP)
-	require.Equal(t, "анекдот!, анкедот!, joke!, chuck!, excuse!, pirozhki!, radiot!, zaibatsu!, excuse_en!, facts!, oneliner! _– расскажет анекдот или шутку_\n",
+	require.Equal(t, "анекдот!, анкедот!, joke!, chuck!, excuse!, pirozhki!, radiot!, zaibatsu!, excuse\\_en!, facts!, oneliner! _– расскажет анекдот или шутку_\n",
 		a.Help())
 }
 
@@ -91,10 +91,18 @@ func TestAnecdotReactsOnChuckMessageUnableToDoReq(t *testing.T) {
 func TestAnecdotReactsOnChuckMessage(t *testing.T) {
 	mockHTTP := &mocks.HTTPClient{DoFunc: func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
-			Body: io.NopCloser(bytes.NewReader([]byte(`{"Value" : {"Joke" : "&quot;joke&quot;"}}`))),
+			Body: io.NopCloser(bytes.NewReader([]byte(`{
+"categories":[],
+"created_at":"2020-01-05 13:42:23.880601",
+"icon_url":"https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+"id":"Lf-jNoPpSZqXoTySlBCtfg",
+"updated_at":"2020-01-05 13:42:23.880601",
+"url":"https://api.chucknorris.io/jokes/Lf-jNoPpSZqXoTySlBCtfg",
+"value":"Chuck Norris got pulled over by a cop once. The cop was lucky to leave with a _warning_."}
+`))),
 		}, nil
 	}}
 	b := NewAnecdote(mockHTTP)
 
-	require.Equal(t, Response{Text: "- \"joke\"", Send: true}, b.OnMessage(Message{Text: "chuck!"}))
+	require.Equal(t, Response{Text: "Chuck Norris got pulled over by a cop once. The cop was lucky to leave with a \\_warning\\_.", Send: true}, b.OnMessage(Message{Text: "chuck!"}))
 }

--- a/app/bot/banhammer.go
+++ b/app/bot/banhammer.go
@@ -28,7 +28,7 @@ type userInfo struct {
 
 // TgBanClient is a subset of tg api limited to ban-related operations only
 type TgBanClient interface {
-	Send(c tbapi.Chattable) (tbapi.Message, error)
+	Request(c tbapi.Chattable) (*tbapi.APIResponse, error)
 }
 
 // NewBanhammer makes a bot for admins reacting on ban!user unban!user
@@ -74,7 +74,7 @@ func (b *Banhammer) OnMessage(msg Message) (response Response) {
 
 	switch cmd {
 	case "ban":
-		_, err := b.tgClient.Send(tbapi.KickChatMemberConfig{
+		_, err := b.tgClient.Request(tbapi.KickChatMemberConfig{
 			ChatMemberConfig: tbapi.ChatMemberConfig{UserID: user.ID, ChatID: msg.ChatID},
 		})
 		if err != nil {
@@ -84,7 +84,7 @@ func (b *Banhammer) OnMessage(msg Message) (response Response) {
 		log.Printf("[INFO] banned %+v by %+v", user.User, msg.From)
 		return Response{Text: fmt.Sprintf("прощай %s", name), Send: true}
 	case "unban":
-		_, err := b.tgClient.Send(tbapi.UnbanChatMemberConfig{ChatMemberConfig: tbapi.ChatMemberConfig{UserID: user.ID, ChatID: msg.ChatID}})
+		_, err := b.tgClient.Request(tbapi.UnbanChatMemberConfig{ChatMemberConfig: tbapi.ChatMemberConfig{UserID: user.ID, ChatID: msg.ChatID}})
 		if err != nil {
 			log.Printf("[WARN] failed to unban %s, %v", name, err)
 			return Response{}

--- a/app/bot/banhammer_test.go
+++ b/app/bot/banhammer_test.go
@@ -50,8 +50,8 @@ func TestBanhammer_OnMessage(t *testing.T) {
 		}
 		return false
 	}}
-	tg := &mocks.TgBanClient{SendFunc: func(c tbapi.Chattable) (tbapi.Message, error) {
-		return tbapi.Message{}, nil
+	tg := &mocks.TgBanClient{RequestFunc: func(c tbapi.Chattable) (*tbapi.APIResponse, error) {
+		return &tbapi.APIResponse{Ok: true}, nil
 	}}
 	b := NewBanhammer(tg, su, 10)
 
@@ -68,9 +68,9 @@ func TestBanhammer_OnMessage(t *testing.T) {
 	assert.Equal(t, Response{Text: "амнистия для user1", Send: true}, resp)
 
 	assert.Equal(t, 5, len(su.IsSuperCalls()))
-	assert.Equal(t, 2, len(tg.SendCalls()))
-	assert.Equal(t, int64(1), tg.SendCalls()[0].C.(tbapi.BanChatMemberConfig).UserID)
-	assert.Equal(t, int64(123), tg.SendCalls()[0].C.(tbapi.BanChatMemberConfig).ChatID)
-	assert.Equal(t, int64(1), tg.SendCalls()[1].C.(tbapi.UnbanChatMemberConfig).UserID)
-	assert.Equal(t, int64(123), tg.SendCalls()[1].C.(tbapi.UnbanChatMemberConfig).ChatID)
+	assert.Equal(t, 2, len(tg.RequestCalls()))
+	assert.Equal(t, int64(1), tg.RequestCalls()[0].C.(tbapi.BanChatMemberConfig).UserID)
+	assert.Equal(t, int64(123), tg.RequestCalls()[0].C.(tbapi.BanChatMemberConfig).ChatID)
+	assert.Equal(t, int64(1), tg.RequestCalls()[1].C.(tbapi.UnbanChatMemberConfig).UserID)
+	assert.Equal(t, int64(123), tg.RequestCalls()[1].C.(tbapi.UnbanChatMemberConfig).ChatID)
 }

--- a/app/bot/bot.go
+++ b/app/bot/bot.go
@@ -20,7 +20,7 @@ import (
 
 // genHelpMsg construct help message from bot's ReactOn
 func genHelpMsg(com []string, msg string) string {
-	return strings.Join(com, ", ") + " _– " + msg + "_\n"
+	return EscapeMarkDownV1Text(strings.Join(com, ", ")) + " _– " + msg + "_\n"
 }
 
 // Interface is a bot reactive spec. response will be sent if "send" result is true
@@ -206,4 +206,15 @@ func makeHTTPRequest(url string) (*http.Request, error) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	return req, nil
+}
+
+// EscapeMarkDownV1Text escapes markdownV1 special characters, used in places where we want to send text as-is.
+// For example, telegram username with underscores would be italicized if we don't escape it.
+// https://core.telegram.org/bots/api#markdown-style
+func EscapeMarkDownV1Text(text string) string {
+	escSymbols := []string{"_", "*", "`", "["}
+	for _, esc := range escSymbols {
+		text = strings.Replace(text, esc, "\\"+esc, -1)
+	}
+	return text
 }

--- a/app/bot/duckduckgo.go
+++ b/app/bot/duckduckgo.go
@@ -71,7 +71,7 @@ func (d *Duck) OnMessage(msg Message) (response Response) {
 		}
 	}
 
-	respMD := fmt.Sprintf("- %s\n[%s](%s)", duckResp.AbstractText, duckResp.AbstractSource, mdLink(duckResp.AbstractURL))
+	respMD := fmt.Sprintf("%s\n[%s](%s)", EscapeMarkDownV1Text(duckResp.AbstractText), duckResp.AbstractSource, mdLink(duckResp.AbstractURL))
 	return Response{
 		Text: respMD,
 		Send: true,

--- a/app/bot/duckduckgo_test.go
+++ b/app/bot/duckduckgo_test.go
@@ -24,7 +24,7 @@ func TestDuck_OnMessage(t *testing.T) {
 	}}
 	d := NewDuck("key", mockHTTP)
 
-	assert.Equal(t, Response{Text: "- the answer\n[test](http://example.com)", Send: true}, d.OnMessage(Message{Text: "?? search"}))
+	assert.Equal(t, Response{Text: "the answer\n[test](http://example.com)", Send: true}, d.OnMessage(Message{Text: "?? search"}))
 }
 
 func TestDuck_request(t *testing.T) {

--- a/app/bot/humanize.go
+++ b/app/bot/humanize.go
@@ -42,5 +42,9 @@ func HumanizeDuration(d time.Duration) string {
 		result += fmt.Sprintf("%vсек", seconds)
 	}
 
+	if d == 666*time.Hour {
+		result += " (666 часов)"
+	}
+
 	return result
 }

--- a/app/bot/mocks/tg_ban_client.go
+++ b/app/bot/mocks/tg_ban_client.go
@@ -14,8 +14,8 @@ import (
 //
 //		// make and configure a mocked bot.TgBanClient
 //		mockedTgBanClient := &TgBanClient{
-//			SendFunc: func(c tbapi.Chattable) (tbapi.Message, error) {
-//				panic("mock out the Send method")
+//			RequestFunc: func(c tbapi.Chattable) (*tbapi.APIResponse, error) {
+//				panic("mock out the Request method")
 //			},
 //		}
 //
@@ -24,48 +24,48 @@ import (
 //
 //	}
 type TgBanClient struct {
-	// SendFunc mocks the Send method.
-	SendFunc func(c tbapi.Chattable) (tbapi.Message, error)
+	// RequestFunc mocks the Request method.
+	RequestFunc func(c tbapi.Chattable) (*tbapi.APIResponse, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// Send holds details about calls to the Send method.
-		Send []struct {
+		// Request holds details about calls to the Request method.
+		Request []struct {
 			// C is the c argument value.
 			C tbapi.Chattable
 		}
 	}
-	lockSend sync.RWMutex
+	lockRequest sync.RWMutex
 }
 
-// Send calls SendFunc.
-func (mock *TgBanClient) Send(c tbapi.Chattable) (tbapi.Message, error) {
-	if mock.SendFunc == nil {
-		panic("TgBanClient.SendFunc: method is nil but TgBanClient.Send was just called")
+// Request calls RequestFunc.
+func (mock *TgBanClient) Request(c tbapi.Chattable) (*tbapi.APIResponse, error) {
+	if mock.RequestFunc == nil {
+		panic("TgBanClient.RequestFunc: method is nil but TgBanClient.Request was just called")
 	}
 	callInfo := struct {
 		C tbapi.Chattable
 	}{
 		C: c,
 	}
-	mock.lockSend.Lock()
-	mock.calls.Send = append(mock.calls.Send, callInfo)
-	mock.lockSend.Unlock()
-	return mock.SendFunc(c)
+	mock.lockRequest.Lock()
+	mock.calls.Request = append(mock.calls.Request, callInfo)
+	mock.lockRequest.Unlock()
+	return mock.RequestFunc(c)
 }
 
-// SendCalls gets all the calls that were made to Send.
+// RequestCalls gets all the calls that were made to Request.
 // Check the length with:
 //
-//	len(mockedTgBanClient.SendCalls())
-func (mock *TgBanClient) SendCalls() []struct {
+//	len(mockedTgBanClient.RequestCalls())
+func (mock *TgBanClient) RequestCalls() []struct {
 	C tbapi.Chattable
 } {
 	var calls []struct {
 		C tbapi.Chattable
 	}
-	mock.lockSend.RLock()
-	calls = mock.calls.Send
-	mock.lockSend.RUnlock()
+	mock.lockRequest.RLock()
+	calls = mock.calls.Request
+	mock.lockRequest.RUnlock()
 	return calls
 }

--- a/app/bot/news.go
+++ b/app/bot/news.go
@@ -62,6 +62,9 @@ func (n News) OnMessage(msg Message) (response Response) {
 
 	var lines []string
 	for _, a := range articles {
+		if a.Title == "" {
+			a.Title = "безымянная новость"
+		}
 		lines = append(lines, fmt.Sprintf("- [%s](%s) %s", a.Title, a.Link, a.Ts.Format("2006-01-02")))
 	}
 	return Response{

--- a/app/bot/news_test.go
+++ b/app/bot/news_test.go
@@ -20,7 +20,7 @@ func TestNewsBot_ReactionOnNewsRequest(t *testing.T) {
 			Ts:    time.Date(2020, 2, 9, 18, 45, 44, 0, time.UTC),
 		},
 		{
-			Title: "title2",
+			Title: "",
 			Link:  "link2",
 			Ts:    time.Date(2020, 2, 10, 18, 45, 45, 0, time.UTC),
 		},
@@ -37,7 +37,7 @@ func TestNewsBot_ReactionOnNewsRequest(t *testing.T) {
 
 	require.Equal(
 		t,
-		Response{Text: "- [title1](link1) 2020-02-09\n- [title2](link2) 2020-02-10" +
+		Response{Text: "- [title1](link1) 2020-02-09\n- [безымянная новость](link2) 2020-02-10" +
 			"\n- [все новости и темы](https://news.radio-t.com)", Send: true},
 		b.OnMessage(Message{Text: "news!"}),
 	)

--- a/app/bot/sys.go
+++ b/app/bot/sys.go
@@ -56,7 +56,7 @@ func (p Sys) OnMessage(msg Message) (response Response) {
 	if strings.EqualFold(msg.Text, "say!") {
 		if p.say != nil && len(p.say) > 0 {
 			return Response{
-				Text: fmt.Sprintf("_%s_", p.say[rand.Intn(len(p.say))]), //nolint:gosec
+				Text: fmt.Sprintf("_%s_", EscapeMarkDownV1Text(p.say[rand.Intn(len(p.say))])), //nolint:gosec
 				Send: true,
 			}
 		}

--- a/app/bot/wtf.go
+++ b/app/bot/wtf.go
@@ -68,7 +68,7 @@ func (w *WTF) OnMessage(msg Message) (response Response) {
 	w.lastWtf = time.Now()
 
 	return Response{
-		Text:        fmt.Sprintf("[%s](tg://user?id=%d) получает бан на %v", mention, wtfUser.ID, HumanizeDuration(banDuration)),
+		Text:        fmt.Sprintf("%s получает бан на %v", EscapeMarkDownV1Text(mention), HumanizeDuration(banDuration)),
 		Send:        true,
 		BanInterval: banDuration,
 		User:        wtfUser,

--- a/app/bot/wtf_test.go
+++ b/app/bot/wtf_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestWTF_OnMessage(t *testing.T) {
 	su := &mocks.SuperUser{IsSuperFunc: func(userName string) bool {
-		if userName == "super" {
+		if userName == "super" || userName == "admin" {
 			return true
 		}
 		return false
@@ -20,49 +20,75 @@ func TestWTF_OnMessage(t *testing.T) {
 	min := time.Hour * 24
 	max := 7 * time.Hour * 24
 	b := NewWTF(min, max, su)
-	b.rand = func(n int64) int64 {
-		return 10
-	}
+	b.rand = func(n int64) int64 { return 10 }
 
-	{ // regular user, first wtf
-		resp := b.OnMessage(Message{Text: "WTF!", From: User{Username: "user", ID: 1}})
-		require.Equal(t, "[@user](tg://user?id=1) получает бан на 1дн 10сек", resp.Text)
+	t.Run("not a wtf message", func(t *testing.T) {
+		resp := b.OnMessage(Message{Text: "unrelevant text"})
+		assert.Empty(t, resp)
+	})
+
+	t.Run("regular user, first wtf", func(t *testing.T) {
+		resp := b.OnMessage(Message{Text: "WTF!", From: User{Username: "user_with_underscores", ID: 1}})
+		require.Equal(t, "@user\\_with\\_underscores получает бан на 1дн 10сек", resp.Text)
 		require.True(t, resp.Send)
 		require.Equal(t, min+10*time.Second, resp.BanInterval)
-		assert.Equal(t, User{Username: "user", ID: 1}, resp.User)
-	}
+		assert.Equal(t, User{Username: "user_with_underscores", ID: 1}, resp.User)
+	})
 
-	{ // regular user, second wtf
-		resp := b.OnMessage(Message{Text: "WTF!", From: User{Username: "user", ID: 1}})
-		require.Equal(t, "[@user](tg://user?id=1) получает бан на 13дн 7ч 10сек", resp.Text)
+	t.Run("regular user, second wtf", func(t *testing.T) {
+		resp := b.OnMessage(Message{Text: "WTF!", From: User{DisplayName: "user display name", ID: 1}})
+		require.Equal(t, "user display name получает бан на 13дн 7ч 10сек", resp.Text)
 		require.True(t, resp.Send)
 		require.Equal(t, min+10*time.Second+59*5*time.Hour, resp.BanInterval)
-	}
+	})
 
-	{ // regular user, third wtf, some time passed since last wtf
+	t.Run("regular user, third wtf, some time passed since last wtf", func(t *testing.T) {
 		time.Sleep(time.Second * 5)
 		resp := b.OnMessage(Message{Text: "WTF!", From: User{Username: "user"}})
-		require.Equal(t, "[@user](tg://user?id=0) получает бан на 12дн 6ч 10сек", resp.Text)
+		require.Equal(t, "@user получает бан на 12дн 6ч 10сек", resp.Text)
 		require.True(t, resp.Send)
 		require.Equal(t, min+10*time.Second+5*54*time.Hour, resp.BanInterval)
-	}
+	})
 
-	{ // admin, allow wtf
+	t.Run("admin, allow wtf", func(t *testing.T) {
 		resp := b.OnMessage(Message{Text: "WTF!", From: User{Username: "super"}})
 		require.Equal(t, "", resp.Text)
 		require.False(t, resp.Send)
 		require.Equal(t, time.Duration(0), resp.BanInterval)
-	}
+	})
 
-	{ // admin, reply wtf
+	t.Run("admin, reply wtf", func(t *testing.T) {
 		msg := Message{Text: "WTF!", From: User{Username: "super"}}
 		msg.ReplyTo.From = User{Username: "user", ID: 1, DisplayName: "User"}
 		resp := b.OnMessage(msg)
-		assert.Equal(t, "[@user](tg://user?id=1) получает бан на 13дн 7ч 10сек", resp.Text)
+		assert.Equal(t, "@user получает бан на 13дн 7ч 10сек", resp.Text)
 		assert.True(t, resp.Send)
 		assert.Equal(t, min+10*time.Second+5*59*time.Hour, resp.BanInterval)
-	}
-	assert.Equal(t, 9, len(su.IsSuperCalls()))
+	})
+
+	t.Run("admin, reply wtf to another admin", func(t *testing.T) {
+		msg := Message{Text: "WTF!", From: User{Username: "super"}}
+		msg.ReplyTo.From = User{Username: "admin", ID: 321}
+		resp := b.OnMessage(msg)
+		assert.Empty(t, resp)
+	})
+
+	t.Run("regular user, magic wtf duration #1", func(t *testing.T) {
+		b.rand = func(n int64) int64 { return 1 }
+		resp := b.OnMessage(Message{Text: "WTF!", From: User{Username: "user"}})
+		require.Equal(t, "@user получает бан на 27дн 18ч (666 часов)", resp.Text)
+		require.True(t, resp.Send)
+		require.Equal(t, time.Hour*666, resp.BanInterval)
+	})
+
+	t.Run("regular user, magic wtf duration #2", func(t *testing.T) {
+		b.rand = func(n int64) int64 { return 2 }
+		resp := b.OnMessage(Message{Text: "WTF!", From: User{Username: "user"}})
+		require.Equal(t, "@user получает бан на 1ч 17мин 7сек", resp.Text)
+		require.True(t, resp.Send)
+		require.Equal(t, time.Minute*77+time.Second*7, resp.BanInterval)
+	})
+	assert.Equal(t, 15, len(su.IsSuperCalls()))
 }
 
 func TestWTF_Help(t *testing.T) {

--- a/app/events/telegram.go
+++ b/app/events/telegram.go
@@ -197,14 +197,14 @@ func (l *TelegramListener) sendBotResponse(resp bot.Response, chatID int64) erro
 	l.saveBotMessage(&res, chatID)
 
 	if resp.Pin {
-		_, err = l.TbAPI.Send(tbapi.PinChatMessageConfig{ChatID: chatID, MessageID: res.MessageID, DisableNotification: true})
+		_, err = l.TbAPI.Request(tbapi.PinChatMessageConfig{ChatID: chatID, MessageID: res.MessageID, DisableNotification: true})
 		if err != nil {
 			return fmt.Errorf("can't pin message to telegram: %w", err)
 		}
 	}
 
 	if resp.Unpin {
-		_, err = l.TbAPI.Send(tbapi.UnpinChatMessageConfig{ChatID: chatID})
+		_, err = l.TbAPI.Request(tbapi.UnpinChatMessageConfig{ChatID: chatID})
 		if err != nil {
 			return fmt.Errorf("can't unpin message to telegram: %w", err)
 		}
@@ -218,7 +218,7 @@ func (l *TelegramListener) applyBan(msg bot.Message, duration time.Duration, cha
 	if msg.From.Username == "" {
 		mention = msg.From.DisplayName
 	}
-	m := fmt.Sprintf("[%s](tg://user?id=%d) _тебя слишком много, отдохни..._", mention, userID)
+	m := fmt.Sprintf("%s _тебя слишком много, отдохни..._", bot.EscapeMarkDownV1Text(mention))
 
 	if err := l.sendBotResponse(bot.Response{Text: m, Send: true}, chatID); err != nil {
 		return fmt.Errorf("failed to send ban message for %v: %w", msg.From, err)
@@ -266,7 +266,6 @@ func (l *TelegramListener) saveBotMessage(msg *tbapi.Message, fromChat int64) {
 // The bot must be an administrator in the supergroup for this to work
 // and must have the appropriate admin rights.
 func (l *TelegramListener) banUser(duration time.Duration, chatID int64, userID int64) error {
-
 	// From Telegram Bot API documentation:
 	// > If user is restricted for more than 366 days or less than 30 seconds from the current time,
 	// > they are considered to be restricted forever

--- a/app/events/terminator.go
+++ b/app/events/terminator.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"fmt"
 	"log"
 	"time"
 
@@ -28,7 +29,6 @@ type ban struct {
 
 // check if user bothered bot too often and ban for BanDuration
 func (t *Terminator) check(user bot.User, sent time.Time, chatID int64) ban {
-
 	noBan := ban{active: false, new: false}
 	if t.Exclude.IsSuper(user.Username) {
 		return noBan
@@ -58,15 +58,20 @@ func (t *Terminator) check(user bot.User, sent time.Time, chatID int64) ban {
 		info.penalty = 0
 	}
 
+	loggedUser := fmt.Sprintf("%v", user)
+	if user.ID == 0 && user.Username == "" {
+		loggedUser = "everyone due to overall bot activity"
+	}
+
 	if info.penalty == t.BanPenalty {
-		log.Printf("[WARN] banned %v", user)
+		log.Printf("[WARN] banned %s", loggedUser)
 		info.penalty++
 		t.users[user][chatID] = info
 		return ban{active: true, new: true}
 	}
 
 	if info.penalty >= t.BanPenalty {
-		log.Printf("[DEBUG] still banned %v", user)
+		log.Printf("[DEBUG] still banned %v", loggedUser)
 		return ban{active: true, new: false}
 	}
 


### PR DESCRIPTION
- Pinning of the messages required to be done with Request and not Send.
- Fix `ban!` calling Send instead of Request as well.
- `help!` messages were unescaped and broken since one of them contained an underscore.
- `chuck!` was not working because the API is not working anymore, replaced  it with a working one.
- `news!` message was not prepared for the scenario of the title absence (like in a tweet).
- Use incoming text in telegram tests as returned message, simplifying them.
- Exclude mock files properly from the coverage report.