### PR TITLE
OpenAI bot: Add system role config with answer limitation

### DIFF
--- a/app/bot/openai.go
+++ b/app/bot/openai.go
@@ -55,6 +55,10 @@ func (o *OpenAI) chatGPTRequest(request string) (response string, err error) {
 			MaxTokens: o.maxTokens,
 			Messages: []openai.ChatCompletionMessage{
 				{
+					Role:    openai.ChatMessageRoleSystem,
+					Content: "You answer with no more than 50 words",
+				},
+				{
 					Role:    openai.ChatMessageRoleUser,
 					Content: r,
 				},

--- a/app/bot/openai_test.go
+++ b/app/bot/openai_test.go
@@ -64,7 +64,8 @@ func TestOpenAI_OnMessage(t *testing.T) {
 			)
 			calls := mockOpenAIClient.CreateChatCompletionCalls()
 			assert.Equal(t, 1, len(calls))
-			assert.Equal(t, tt.request, calls[0].ChatCompletionRequest.Messages[0].Content)
+			// First message is system role setup
+			assert.Equal(t, tt.request, calls[0].ChatCompletionRequest.Messages[1].Content)
 		})
 	}
 


### PR DESCRIPTION
**Problem**
Answers of ChatGPT are too long

**Solution**
The OpenAI API is using system message to define the behavior of answers. This PR is adding definition of answer length as 50 words.

**Example**
<img width="510" alt="Screenshot 2023-03-18 at 11 11 42 AM" src="https://user-images.githubusercontent.com/1496873/226126202-dce97b3e-fca3-4a67-ab16-510f7d00e9bd.png">
