### PR TITLE
Use boolean `IsReply` instead of `ReplyTo` in bot actions

### DIFF
--- a/app/bot/bot.go
+++ b/app/bot/bot.go
@@ -40,7 +40,6 @@ type Response struct {
 	BanInterval time.Duration // bots banning user set the interval
 	User        User          // user to ban
 	ChannelID   int64         // channel to ban, if set then User and BanInterval are ignored
-	ReplyTo     int           // message to reply to, if 0 then no reply but common message
 	IsReply     bool          // is this a reply to the message. Used to avoid using wrong message id in the user's bots
 }
 
@@ -147,7 +146,7 @@ func (b MultiBot) OnMessage(msg Message) (response Response) {
 	var banInterval time.Duration
 	var user User
 	var mutex = &sync.Mutex{}
-	var replyTo int
+	var isReply bool
 
 	wg := syncs.NewSizedGroup(4)
 	for _, bot := range b {
@@ -161,11 +160,8 @@ func (b MultiBot) OnMessage(msg Message) (response Response) {
 				if resp.Unpin {
 					atomic.AddInt32(&unpin, 1)
 				}
-				if resp.ReplyTo > 0 {
-					replyTo = resp.ReplyTo
-				}
 				if resp.IsReply {
-					replyTo = msg.ID
+					isReply = true
 				}
 				if resp.BanInterval > 0 {
 					mutex.Lock()
@@ -204,8 +200,7 @@ func (b MultiBot) OnMessage(msg Message) (response Response) {
 		BanInterval: banInterval,
 		User:        user,
 		ChannelID:   channelID,
-		ReplyTo:     replyTo,
-		IsReply:     replyTo > 0, // This message is reply to another message with non-zero ID
+		IsReply:     isReply,
 	}
 }
 

--- a/app/bot/bot.go
+++ b/app/bot/bot.go
@@ -41,6 +41,7 @@ type Response struct {
 	User        User          // user to ban
 	ChannelID   int64         // channel to ban, if set then User and BanInterval are ignored
 	ReplyTo     int           // message to reply to, if 0 then no reply but common message
+	IsReply     bool          // is this a reply to the message. Used to avoid using wrong message id in the user's bots
 }
 
 // HTTPClient wrap http.Client to allow mocking
@@ -163,6 +164,9 @@ func (b MultiBot) OnMessage(msg Message) (response Response) {
 				if resp.ReplyTo > 0 {
 					replyTo = resp.ReplyTo
 				}
+				if resp.IsReply {
+					replyTo = msg.ID
+				}
 				if resp.BanInterval > 0 {
 					mutex.Lock()
 					if resp.BanInterval > banInterval {
@@ -201,6 +205,7 @@ func (b MultiBot) OnMessage(msg Message) (response Response) {
 		User:        user,
 		ChannelID:   channelID,
 		ReplyTo:     replyTo,
+		IsReply:     replyTo > 0, // This message is reply to another message with non-zero ID
 	}
 }
 

--- a/app/bot/bot_test.go
+++ b/app/bot/bot_test.go
@@ -47,7 +47,7 @@ func TestMultiBotCombinesAllBotResponses(t *testing.T) {
 
 	b1 := &InterfaceMock{
 		ReactOnFunc:   func() []string { return []string{"cmd"} },
-		OnMessageFunc: func(m Message) Response { return Response{Send: true, Text: "b1 resp", ReplyTo: 789} },
+		OnMessageFunc: func(m Message) Response { return Response{Send: true, Text: "b1 resp", IsReply: true} },
 	}
 	b2 := &InterfaceMock{
 		ReactOnFunc:   func() []string { return []string{"cmd"} },
@@ -63,5 +63,5 @@ func TestMultiBotCombinesAllBotResponses(t *testing.T) {
 	require.Len(t, parts, 2)
 	require.Contains(t, parts, "b1 resp")
 	require.Contains(t, parts, "b2 resp")
-	assert.Equal(t, 789, resp.ReplyTo)
+	assert.Equal(t, true, resp.IsReply)
 }

--- a/app/bot/openai.go
+++ b/app/bot/openai.go
@@ -60,7 +60,7 @@ func (o *OpenAI) OnMessage(msg Message) (response Response) {
 			Send:        true,
 			BanInterval: time.Hour,
 			User:        msg.From,
-			ReplyTo:     msg.ID, // reply to the message
+			IsReply:     true, // reply to the message
 		}
 	}
 
@@ -79,7 +79,7 @@ func (o *OpenAI) OnMessage(msg Message) (response Response) {
 	return Response{
 		Text:    responseAI,
 		Send:    true,
-		ReplyTo: msg.ID, // reply to the message
+		IsReply: true, // reply to the message
 	}
 }
 

--- a/app/bot/openai_test.go
+++ b/app/bot/openai_test.go
@@ -34,8 +34,8 @@ func TestOpenAI_OnMessage(t *testing.T) {
 		mockResult bool
 		response   Response
 	}{
-		{"Good result", "prompt", jsonResponse, true, Response{Text: "Mock response", Send: true, ReplyTo: 756}},
-		{"Good result", "", jsonResponse, true, Response{Text: "Mock response", Send: true, ReplyTo: 756}},
+		{"Good result", "prompt", jsonResponse, true, Response{Text: "Mock response", Send: true, ReplyTo: 0, IsReply: true}},
+		{"Good result", "", jsonResponse, true, Response{Text: "Mock response", Send: true, ReplyTo: 0, IsReply: true}},
 		{"Error result", "", jsonResponse, false, Response{}},
 		{"Empty result", "", []byte(`{}`), true, Response{}},
 	}
@@ -108,7 +108,8 @@ func TestOpenAI_OnMessage_TooManyRequests(t *testing.T) {
 		resp := o.OnMessage(Message{Text: "chat! something", ID: 756})
 		require.True(t, resp.Send)
 		assert.Equal(t, "Mock response", resp.Text)
-		assert.Equal(t, 756, resp.ReplyTo)
+		assert.Equal(t, true, resp.IsReply)
+		assert.Equal(t, 0, resp.ReplyTo)
 		assert.Equal(t, time.Duration(0), resp.BanInterval)
 	}
 
@@ -116,7 +117,8 @@ func TestOpenAI_OnMessage_TooManyRequests(t *testing.T) {
 		resp := o.OnMessage(Message{Text: "chat! something", ID: 756})
 		require.True(t, resp.Send)
 		assert.Contains(t, resp.Text, "Слишком много запросов,")
-		assert.Equal(t, 756, resp.ReplyTo)
+		assert.Equal(t, true, resp.IsReply)
+		assert.Equal(t, 0, resp.ReplyTo)
 		assert.Equal(t, time.Hour, resp.BanInterval)
 	}
 
@@ -126,7 +128,8 @@ func TestOpenAI_OnMessage_TooManyRequests(t *testing.T) {
 		resp := o.OnMessage(req)
 		require.True(t, resp.Send)
 		assert.Equal(t, "Mock response", resp.Text)
-		assert.Equal(t, 756, resp.ReplyTo)
+		assert.Equal(t, true, resp.IsReply)
+		assert.Equal(t, 0, resp.ReplyTo)
 		assert.Equal(t, time.Duration(0), resp.BanInterval)
 	}
 
@@ -137,7 +140,8 @@ func TestOpenAI_OnMessage_TooManyRequests(t *testing.T) {
 		resp := o.OnMessage(Message{Text: "chat! something", ID: 756})
 		require.True(t, resp.Send)
 		assert.Equal(t, "Mock response", resp.Text)
-		assert.Equal(t, 756, resp.ReplyTo)
+		assert.Equal(t, true, resp.IsReply)
+		assert.Equal(t, 0, resp.ReplyTo)
 		assert.Equal(t, time.Duration(0), resp.BanInterval)
 	}
 }

--- a/app/bot/openai_test.go
+++ b/app/bot/openai_test.go
@@ -34,8 +34,8 @@ func TestOpenAI_OnMessage(t *testing.T) {
 		mockResult bool
 		response   Response
 	}{
-		{"Good result", "prompt", jsonResponse, true, Response{Text: "Mock response", Send: true, ReplyTo: 0, IsReply: true}},
-		{"Good result", "", jsonResponse, true, Response{Text: "Mock response", Send: true, ReplyTo: 0, IsReply: true}},
+		{"Good result", "prompt", jsonResponse, true, Response{Text: "Mock response", Send: true, IsReply: true}},
+		{"Good result", "", jsonResponse, true, Response{Text: "Mock response", Send: true, IsReply: true}},
 		{"Error result", "", jsonResponse, false, Response{}},
 		{"Empty result", "", []byte(`{}`), true, Response{}},
 	}
@@ -109,7 +109,6 @@ func TestOpenAI_OnMessage_TooManyRequests(t *testing.T) {
 		require.True(t, resp.Send)
 		assert.Equal(t, "Mock response", resp.Text)
 		assert.Equal(t, true, resp.IsReply)
-		assert.Equal(t, 0, resp.ReplyTo)
 		assert.Equal(t, time.Duration(0), resp.BanInterval)
 	}
 
@@ -118,7 +117,6 @@ func TestOpenAI_OnMessage_TooManyRequests(t *testing.T) {
 		require.True(t, resp.Send)
 		assert.Contains(t, resp.Text, "Слишком много запросов,")
 		assert.Equal(t, true, resp.IsReply)
-		assert.Equal(t, 0, resp.ReplyTo)
 		assert.Equal(t, time.Hour, resp.BanInterval)
 	}
 
@@ -129,7 +127,6 @@ func TestOpenAI_OnMessage_TooManyRequests(t *testing.T) {
 		require.True(t, resp.Send)
 		assert.Equal(t, "Mock response", resp.Text)
 		assert.Equal(t, true, resp.IsReply)
-		assert.Equal(t, 0, resp.ReplyTo)
 		assert.Equal(t, time.Duration(0), resp.BanInterval)
 	}
 
@@ -141,7 +138,6 @@ func TestOpenAI_OnMessage_TooManyRequests(t *testing.T) {
 		require.True(t, resp.Send)
 		assert.Equal(t, "Mock response", resp.Text)
 		assert.Equal(t, true, resp.IsReply)
-		assert.Equal(t, 0, resp.ReplyTo)
 		assert.Equal(t, time.Duration(0), resp.BanInterval)
 	}
 }

--- a/app/events/telegram.go
+++ b/app/events/telegram.go
@@ -230,15 +230,13 @@ func (l *TelegramListener) sendBotResponse(resp bot.Response, ctx MessageContext
 		return nil
 	}
 
-	log.Printf("[DEBUG] bot response - %+v, pin: %t, reply-to:%d", resp.Text, resp.Pin, resp.ReplyTo)
+	log.Printf("[DEBUG] bot response - %+v, pin: %t, is-reply: %t (%d)", resp.Text, resp.Pin, resp.IsReply, ctx.MsgID)
 	tbMsg := tbapi.NewMessage(ctx.ChatID, resp.Text)
 	tbMsg.ParseMode = tbapi.ModeMarkdown
 	tbMsg.DisableWebPagePreview = !resp.Preview
 	// Get the message ID to reply to directly from the update context
 	if resp.IsReply {
 		tbMsg.ReplyToMessageID = ctx.MsgID
-	} else {
-		tbMsg.ReplyToMessageID = resp.ReplyTo
 	}
 	res, err := l.TbAPI.Send(tbMsg)
 	if err != nil {


### PR DESCRIPTION
`OnMessage` method in user's bots shouldn't set `ReplyTo` param to answer on user's message. This provides extra complexity and opens possibility to set another id.

This PR replaced `ReplyTo` to `IsReply` boolean, which is using during sending the real message in TelegramListener object.
Additionalty `fromChat` was replaced for `fromCtx` context for original user's message.

**Next steps**
I'm going to use this PR for saving the chain of messages in the communication with bot.