### PR TITLE
Using WTFSteroidChecker in OpenAI bot for request and response

### DIFF
--- a/app/bot/testdata/chat_completion_wtf_response.json
+++ b/app/bot/testdata/chat_completion_wtf_response.json
@@ -1,0 +1,18 @@
+{
+  "id": "chatcmpl-123",
+  "object": "chat.completion",
+  "created": 1677652288,
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "content": "Mock response with wtf"
+    },
+    "finish_reason": "stop"
+  }],
+  "usage": {
+    "prompt_tokens": 9,
+    "completion_tokens": 12,
+    "total_tokens": 21
+  }
+}

--- a/app/bot/wtfsteroidchecker.go
+++ b/app/bot/wtfsteroidchecker.go
@@ -501,17 +501,30 @@ func (w *WTFSteroidChecker) removeNotLetters() {
 	}, w.message)
 }
 
-// Contains remove all bad symbols from message and check if the message contained the commands
-func (w *WTFSteroidChecker) Contains() bool {
-
+// CleanUp remove all bad symbols from message
+func (w *WTFSteroidChecker) CleanUp() {
 	w.message = strings.ToLower(w.message)
 	w.removeUnicodeDiacriticAnalog()
 	w.removeDiacritic()
 	w.removeUnicodeAnalog()
 	w.removeNotASCIIAndNotRussian()
 	w.removeNotLetters()
+}
+
+// Contains remove all bad symbols from message and check if the message contained the commands
+func (w *WTFSteroidChecker) Contains() bool {
+
+	w.CleanUp()
 
 	// Straight and reverse order
 	return contains([]string{"wtf!", "wtf?"}, w.message) || contains([]string{"!ftw", "?ftw"}, w.message)
 
+}
+
+// ContainsWTF remove all bad symbols from message and check if the message contained substring with "wtf"
+func (w *WTFSteroidChecker) ContainsWTF() bool {
+
+	w.CleanUp()
+
+	return strings.Contains(w.message, "wtf")
 }

--- a/app/bot/wtfsteroidchecker_test.go
+++ b/app/bot/wtfsteroidchecker_test.go
@@ -169,6 +169,165 @@ func TestWTFSteroidChecker_Contains(t *testing.T) {
 	}
 }
 
+func TestWTFSteroidChecker_ContainsWTF(t *testing.T) {
+	type fields struct {
+		message string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{name: "WTF",
+			fields: fields{
+				message: "WTF",
+			},
+			want: true},
+		{name: "втф",
+			fields: fields{
+				message: "втф",
+			},
+			want: true},
+		{name: "WT\ufff0F",
+			fields: fields{
+				message: "WT￰F",
+			},
+			want: true},
+		{name: "WtF",
+			fields: fields{
+				message: "WtF",
+			},
+			want: true},
+		{name: "𝀥tf",
+			fields: fields{
+				message: "𝀥tf",
+			},
+			want: true},
+		{name: "ẂTF",
+			fields: fields{
+				message: "ẂTF",
+			},
+			want: true},
+		{name: "W TF",
+			fields: fields{
+				message: "W TF",
+			},
+			want: true},
+		{name: "wtf",
+			fields: fields{
+				message: "wtf",
+			},
+			want: true},
+		{name: "wtf",
+			fields: fields{
+				message: "wtf",
+			},
+			want: true},
+		{name: "🅦🅣ⓕ",
+			fields: fields{
+				message: "🅦🅣ⓕ",
+			},
+			want: true},
+		{name: "w-t-f",
+			fields: fields{
+				message: "w-t-f",
+			},
+			want: true},
+		{name: "w;t;f",
+			fields: fields{
+				message: "w;t;f",
+			},
+			want: true},
+		{name: "W T F",
+			fields: fields{
+				message: "W T F",
+			},
+			want: true},
+		{name: "W῝🇹🶪Ꝼ",
+			fields: fields{
+				message: "W῝🇹🶪Ꝼ",
+			},
+			want: true},
+		{name: "WTḞ",
+			fields: fields{
+				message: "WTḞ",
+			},
+			want: true},
+		{name: "W\x05TF",
+			fields: fields{
+				message: "W\x05TF",
+			},
+			want: true},
+		{name: "Вот фон! - false",
+			fields: fields{
+				message: "Вот фон!",
+			},
+			want: false},
+		{name: "W؈T؈F؈",
+			fields: fields{
+				message: "W؈T؈F؈",
+			},
+			want: true},
+		{name: "Что за втф - true",
+			fields: fields{
+				message: "Что за втф",
+			},
+			want: true},
+		{name: "Что за wtf - true",
+			fields: fields{
+				message: "Что за wtf",
+			},
+			want: true},
+		{name: "VVtf",
+			fields: fields{
+				message: "VVtf",
+			},
+			want: true},
+		{name: "¡ɟʇʍ",
+			fields: fields{
+				message: "¡ɟʇʍ",
+			},
+			want: false},
+		{name: "¿ɟʇʍ",
+			fields: fields{
+				message: "¿ɟʇʍ",
+			},
+			want: false},
+		{name: "wtᷫ",
+			fields: fields{
+				message: "wtᷫ",
+			},
+			want: true},
+		{name: "wtᷥ",
+			fields: fields{
+				message: "wtᷥ",
+			},
+			want: true},
+		{name: "¡ȸɯʚ",
+			fields: fields{
+				message: "¡ȸɯʚ",
+			},
+			want: false},
+		{name: "¿ȸɯʚ",
+			fields: fields{
+				message: "¿ȸɯʚ",
+			},
+			want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &WTFSteroidChecker{
+				message: tt.fields.message,
+			}
+			if got := w.ContainsWTF(); got != tt.want {
+				t.Errorf("WTFSteroidChecker.ContainsWTF() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+}
+
 // TestWTFSteroidChecker_WTFUnicodeLibrary_Unique_Check check that all symbols in the library are unique
 // and key ASCII symbol is not in library
 func TestWTFSteroidChecker_WTFUnicodeLibrary_Unique_Check(t *testing.T) {


### PR DESCRIPTION
**Problem**
Many users are making requests to OpenAI bot with the reason to receive "wtf" response.

**Solution**
Using `WTFSteroidChecker` for checking request and response to OpenAI bot for "wtf". If it contains, then ban the user for 1 hour

**Example**
<img width="499" alt="Screenshot 2023-03-24 at 2 44 09 PM" src="https://user-images.githubusercontent.com/1496873/227646933-ad4f416f-ebe8-452d-bfcc-59705aa80acf.png">

