### PR TITLE
Random context answers for chat questions

### DIFF
--- a/app/bot/openaihistory.go
+++ b/app/bot/openaihistory.go
@@ -1,0 +1,28 @@
+package bot
+
+// LimitedMessageHistory is a limited message history for OpenAI bot
+// It's using to make context answers in the chat
+// This isn't thread safe structure
+type LimitedMessageHistory struct {
+	limit    int
+	count    int
+	messages []Message
+}
+
+// NewLimitedMessageHistory makes a new LimitedMessageHistory with limit
+func NewLimitedMessageHistory(limit int) LimitedMessageHistory {
+	return LimitedMessageHistory{
+		limit:    limit,
+		count:    0,
+		messages: make([]Message, 0, limit),
+	}
+}
+
+// Add adds a new message to the history
+func (l *LimitedMessageHistory) Add(message Message) {
+	l.count++
+	l.messages = append(l.messages, message)
+	if len(l.messages) > l.limit {
+		l.messages = l.messages[1:]
+	}
+}

--- a/app/bot/openaihistory_test.go
+++ b/app/bot/openaihistory_test.go
@@ -1,0 +1,59 @@
+package bot
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_LimitedMessageHistory(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int
+	}{
+		{name: "Limit 5", limit: 5},
+		{name: "Limit 10", limit: 10},
+		{name: "Limit 20", limit: 20},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			history := NewLimitedMessageHistory(tt.limit)
+
+			// Add `limit` messages to the storage
+			for i := 0; i < tt.limit; i++ {
+				history.Add(Message{
+					ID:   i,
+					Text: fmt.Sprintf("test %d", i),
+				})
+
+				assert.Equal(t, i+1, len(history.messages))
+			}
+
+			assert.Equal(t, tt.limit, len(history.messages))
+			for i := 0; i < tt.limit; i++ {
+				assert.Equal(t, i, history.messages[i].ID)
+				assert.Equal(t, fmt.Sprintf("test %d", i), history.messages[i].Text)
+			}
+
+			// Add messages to the storage. This should remove the oldest messages
+			for j := 0; j < 3; j++ {
+				newID := tt.limit + j
+				history.Add(Message{
+					ID:   newID,
+					Text: fmt.Sprintf("test %d", newID),
+				})
+
+				assert.Equal(t, tt.limit, len(history.messages))
+				for i := 0; i < tt.limit; i++ {
+					expectedID := i + j + 1
+					assert.Equal(t, expectedID, history.messages[i].ID)
+					assert.Equal(t, fmt.Sprintf("test %d", expectedID), history.messages[i].Text)
+				}
+			}
+
+		})
+	}
+
+}

--- a/app/main.go
+++ b/app/main.go
@@ -48,8 +48,8 @@ var opts struct {
 		MaxTokens int    `long:"max-tokens" env:"MAX_TOKENS" default:"1000" description:"OpenAI max_tokens in response"`
 		Prompt    string `long:"prompt" env:"PROMPT" default:"" description:"OpenAI prompt"`
 
-		HistorySize     int   `long:"history-size" env:"HISTORY_SIZE" default:"5" description:"OpenAI history size for context answers"`
-		HistoryRandBase int64 `long:"history-rand-base" env:"HISTORY_RAND_BASE" default:"10" description:"OpenAI random base for context answers. By default 10 means 1/10 = 10% of answer probability"`
+		HistorySize             int `long:"history-size" env:"HISTORY_SIZE" default:"5" description:"OpenAI history size for context answers"`
+		HistoryReplyProbability int `long:"history-reply-probability" env:"HISTORY_REPLY_PROBABILITY" default:"10" description:"Percentage of the probability to reply with history (0%-100%)"`
 
 		Timeout time.Duration `long:"timeout" env:"TIMEOUT" default:"120s" description:"OpenAI timeout in seconds"`
 	} `group:"openai" namespace:"openai" env-namespace:"OPENAI"`
@@ -88,12 +88,12 @@ func main() {
 	httpClient := &http.Client{Timeout: 5 * time.Second}
 	// 5 seconds is not enough for OpenAI requests
 	httpClientOpenAI := makeOpenAIHttpClient()
-	openAIBot := bot.NewOpenAI(bot.OpenAIConfig{
-		AuthToken:       opts.OpenAI.AuthToken,
-		MaxTokens:       opts.OpenAI.MaxTokens,
-		Prompt:          opts.OpenAI.Prompt,
-		HistorySize:     opts.OpenAI.HistorySize,
-		HistoryRandBase: opts.OpenAI.HistoryRandBase,
+	openAIBot := bot.NewOpenAI(bot.OpenAIParams{
+		AuthToken:               opts.OpenAI.AuthToken,
+		MaxTokens:               opts.OpenAI.MaxTokens,
+		Prompt:                  opts.OpenAI.Prompt,
+		HistorySize:             opts.OpenAI.HistorySize,
+		HistoryReplyProbability: opts.OpenAI.HistoryReplyProbability,
 	}, httpClientOpenAI, opts.SuperUsers)
 
 	multiBot := bot.MultiBot{


### PR DESCRIPTION
**Idea**
Added `LimitedMessageHistory` to save last N messages in the chat (N=5 or more). When somebody ask the question or just randomly, the bot is awake and answer with using context of last N messages.

**Implementation**
The OpenAI bot stores in `LimitedMessageHistory` all messages which wasn't addressed directly to OpenAI bot. This makes the context for future requests to OpenAI API.

When the history has enough messages (>= N, where N is limit), any question (message ends with ?) may be addressed to Chat GPT with 10% probability.

**Example**

<img width="511" alt="Screenshot 2023-03-24 at 3 52 41 PM" src="https://user-images.githubusercontent.com/1496873/227657143-39909e2e-31a4-4372-b7c5-8b8903ac17a8.png">


Issue #93 
