### PR TITLE
Fix problem with `EnableAutoResponse`

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -95,6 +95,7 @@ func main() {
 		Prompt:                  opts.OpenAI.Prompt,
 		HistorySize:             opts.OpenAI.HistorySize,
 		HistoryReplyProbability: opts.OpenAI.HistoryReplyProbability,
+		EnableAutoResponse:      opts.OpenAI.EnableAutoResponse,
 	}, httpClientOpenAI, opts.SuperUsers)
 
 	multiBot := bot.MultiBot{


### PR DESCRIPTION
@umputun added new command line param, which was never provided to OpenAI bot. As result, the feature of context answers with using history was always disabled