### PR TITLE
case insensitive command for openai

### DIFF
--- a/app/bot/openai.go
+++ b/app/bot/openai.go
@@ -130,9 +130,10 @@ func (o *OpenAI) OnMessage(msg Message) (response Response) {
 }
 
 func (o *OpenAI) request(text string) (react bool, reqText string) {
+	textLowerCase := strings.ToLower(text)
 	for _, prefix := range o.ReactOn() {
-		if strings.HasPrefix(text, prefix) {
-			return true, strings.TrimSpace(strings.TrimPrefix(text, prefix))
+		if strings.HasPrefix(textLowerCase, prefix) {
+			return true, strings.TrimSpace(text[len(prefix):])
 		}
 	}
 	return false, ""

--- a/app/bot/openai_test.go
+++ b/app/bot/openai_test.go
@@ -419,11 +419,13 @@ func TestOpenAI_request(t *testing.T) {
 		req  string
 	}{
 		{"chat! valid request", true, "valid request"},
+		{"Chat! valid request", true, "valid request"},
 		{"", false, ""},
 		{"not valid request", false, ""},
 		{"chat not valid request", false, ""},
 		{"blah chat! test", false, ""},
 		{"gpt! chat test", true, "chat test"},
+		{"gPt! 😮‍💨 unicode case", true, "😮‍💨 unicode case"},
 	}
 
 	o := &OpenAI{}


### PR DESCRIPTION
using mobile client phones usually automatically correct the first word with capital letter, that happens in the chat sometimes. This should fix the case