### PR TITLE
add spam filter with CAS api https://cas.chat/api

### DIFF
--- a/app/bot/bot.go
+++ b/app/bot/bot.go
@@ -32,16 +32,17 @@ type Interface interface {
 
 // Response describes bot's answer on particular message
 type Response struct {
-	Text        string
-	Send        bool          // status
-	Pin         bool          // enable pin
-	Unpin       bool          // enable unpin
-	Preview     bool          // enable web preview
-	BanInterval time.Duration // bots banning user set the interval
-	User        User          // user to ban
-	ChannelID   int64         // channel to ban, if set then User and BanInterval are ignored
-	ReplyTo     int           // message to reply to, if 0 then no reply but common message
-	ParseMode   string        // parse mode for message in Telegram (we use Markdown by default)
+	Text          string
+	Send          bool          // status
+	Pin           bool          // enable pin
+	Unpin         bool          // enable unpin
+	Preview       bool          // enable web preview
+	BanInterval   time.Duration // bots banning user set the interval
+	User          User          // user to ban
+	ChannelID     int64         // channel to ban, if set then User and BanInterval are ignored
+	ReplyTo       int           // message to reply to, if 0 then no reply but common message
+	ParseMode     string        // parse mode for message in Telegram (we use Markdown by default)
+	DeleteReplyTo bool          // delete message what bot replays to
 }
 
 // HTTPClient wrap http.Client to allow mocking

--- a/app/bot/spam.go
+++ b/app/bot/spam.go
@@ -1,0 +1,74 @@
+package bot
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+type SpamFilter struct {
+	casAPI string
+	dry    bool
+	client HTTPClient
+
+	approvedUsers map[int64]bool
+}
+
+// If user is restricted for more than 366 days or less than 30 seconds from the current time,
+// they are considered to be restricted forever.
+var permanentBanDuration = time.Hour * 24 * 400
+
+// NewSpamFilter makes a spam detecting bot
+func NewSpamFilter(api string, client HTTPClient, dry bool) *SpamFilter {
+	log.Printf("[INFO] Excerpt bot with %s", api)
+	return &SpamFilter{casAPI: api, client: client, dry: dry, approvedUsers: map[int64]bool{}}
+}
+
+func (s *SpamFilter) OnMessage(msg Message) (response Response) {
+	if s.approvedUsers[msg.From.ID] {
+		return Response{}
+	}
+
+	reqURL := fmt.Sprintf("%s/check?user_id=%d", s.casAPI, msg.From.ID)
+	req, err := http.NewRequest("GET", reqURL, http.NoBody)
+	if err != nil {
+		log.Printf("[WARN] failed to make request %s, error=%v", reqURL, err)
+		return Response{}
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		log.Printf("[WARN] failed to send request %s, error=%v", reqURL, err)
+		return Response{}
+	}
+	defer resp.Body.Close()
+
+	respData := struct {
+		OK          bool   `json:"ok"`
+		Description string `json:"description"`
+	}{}
+
+	if err := json.NewDecoder(resp.Body).Decode(&respData); err != nil {
+		log.Printf("[WARN] failed to parse response from %s, error=%v", reqURL, err)
+		return Response{}
+	}
+	if respData.OK {
+		log.Printf("[INFO] user %s is not a spammer, added to aproved", msg.From.Username)
+		s.approvedUsers[msg.From.ID] = true
+		return Response{}
+	}
+
+	log.Printf("[INFO] user %s detected as spammer: %s, msg: %s", msg.From.Username, respData.Description, msg.Text)
+	if s.dry {
+		return Response{Text: "this is spam, but I'm in dry mode, so I'll do nothing yet", Send: true, ReplyTo: msg.ID}
+	}
+	return Response{Text: "this is spam, go to ban " + msg.From.DisplayName, Send: true, ReplyTo: msg.ID, BanInterval: permanentBanDuration, DeleteReplyTo: true}
+}
+
+// Help returns help message
+func (s *SpamFilter) Help() string { return "" }
+
+// ReactOn keys
+func (s *SpamFilter) ReactOn() []string { return []string{} }

--- a/app/bot/spam.go
+++ b/app/bot/spam.go
@@ -66,7 +66,7 @@ func (s *SpamFilter) OnMessage(msg Message) (response Response) {
 	if s.dry {
 		return Response{Text: "this is spam, but I'm in dry mode, so I'll do nothing yet", Send: true, ReplyTo: msg.ID}
 	}
-	return Response{Text: "this is spam, go to ban " + msg.From.DisplayName, Send: true, ReplyTo: msg.ID, BanInterval: permanentBanDuration, DeleteReplyTo: true}
+	return Response{Text: "this is spam! go to ban, " + msg.From.DisplayName, Send: true, ReplyTo: msg.ID, BanInterval: permanentBanDuration, DeleteReplyTo: true}
 }
 
 // Help returns help message

--- a/app/bot/spam.go
+++ b/app/bot/spam.go
@@ -8,6 +8,7 @@ import (
 	"time"
 )
 
+// SpamFilter bot, checks if user is a spammer using CAS API
 type SpamFilter struct {
 	casAPI string
 	dry    bool
@@ -26,6 +27,7 @@ func NewSpamFilter(api string, client HTTPClient, dry bool) *SpamFilter {
 	return &SpamFilter{casAPI: api, client: client, dry: dry, approvedUsers: map[int64]bool{}}
 }
 
+// OnMessage checks if user already approved and if not checks if user is a spammer
 func (s *SpamFilter) OnMessage(msg Message) (response Response) {
 	if s.approvedUsers[msg.From.ID] {
 		return Response{}

--- a/app/bot/spam_test.go
+++ b/app/bot/spam_test.go
@@ -41,7 +41,7 @@ func TestSpamFilter_OnMessage(t *testing.T) {
 			mockStatusCode: 200,
 			dryMode:        false,
 			expectedResp: Response{
-				Text:          "this is spam, go to ban Test User",
+				Text:          "this is spam! go to ban, Test User",
 				Send:          true,
 				ReplyTo:       1,
 				BanInterval:   permanentBanDuration,

--- a/app/bot/spam_test.go
+++ b/app/bot/spam_test.go
@@ -1,0 +1,122 @@
+package bot
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/radio-t/super-bot/app/bot/mocks"
+)
+
+func TestNewSpamFilter(t *testing.T) {
+	client := &mocks.HTTPClient{}
+	sf := NewSpamFilter("http://localhost", client, false)
+	assert.NotNil(t, sf)
+	assert.Equal(t, "http://localhost", sf.casAPI)
+	assert.Equal(t, client, sf.client)
+	assert.False(t, sf.dry)
+}
+
+func TestSpamFilter_OnMessage(t *testing.T) {
+	tests := []struct {
+		name           string
+		mockResp       string
+		mockStatusCode int
+		dryMode        bool
+		expectedResp   Response
+	}{
+		{
+			name:           "User is not a spammer",
+			mockResp:       `{"ok": true, "description": "Not a spammer"}`,
+			mockStatusCode: 200,
+			dryMode:        false,
+			expectedResp:   Response{},
+		},
+		{
+			name:           "User is a spammer, not in dry mode",
+			mockResp:       `{"ok": false, "description": "Is a spammer"}`,
+			mockStatusCode: 200,
+			dryMode:        false,
+			expectedResp: Response{
+				Text:          "this is spam, go to ban Test User",
+				Send:          true,
+				ReplyTo:       1,
+				BanInterval:   permanentBanDuration,
+				DeleteReplyTo: true,
+			},
+		},
+		{
+			name:           "User is a spammer, in dry mode",
+			mockResp:       `{"ok": false, "description": "Is a spammer"}`,
+			mockStatusCode: 200,
+			dryMode:        true,
+			expectedResp: Response{
+				Text:    "this is spam, but I'm in dry mode, so I'll do nothing yet",
+				Send:    true,
+				ReplyTo: 1,
+			},
+		},
+		{
+			name:           "HTTP error",
+			mockResp:       "",
+			mockStatusCode: 500,
+			dryMode:        false,
+			expectedResp:   Response{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockedHTTPClient := &mocks.HTTPClient{
+				DoFunc: func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: tt.mockStatusCode,
+						Body:       io.NopCloser(bytes.NewBufferString(tt.mockResp)),
+					}, nil
+				},
+			}
+
+			s := NewSpamFilter("http://localhost", mockedHTTPClient, tt.dryMode)
+
+			msg := Message{
+				From: User{
+					ID:          1,
+					Username:    "testuser",
+					DisplayName: "Test User",
+				},
+				ID:   1,
+				Text: "Hello",
+			}
+
+			resp := s.OnMessage(msg)
+			assert.Equal(t, tt.expectedResp, resp)
+		})
+	}
+}
+
+func TestSpamFilter_OnMessageCheckOnce(t *testing.T) {
+	mockedHTTPClient := &mocks.HTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewBufferString(`{"ok": true, "description": "Not a spammer"}`)),
+			}, nil
+		},
+	}
+
+	s := NewSpamFilter("http://localhost", mockedHTTPClient, false)
+	res := s.OnMessage(Message{From: User{ID: 1, Username: "testuser"}, ID: 1, Text: "Hello"})
+	assert.Equal(t, Response{}, res)
+	assert.Len(t, mockedHTTPClient.DoCalls(), 1, "Do should be called once")
+
+	res = s.OnMessage(Message{From: User{ID: 1, Username: "testuser"}, ID: 1, Text: "Hello"})
+	assert.Equal(t, Response{}, res)
+	assert.Len(t, mockedHTTPClient.DoCalls(), 1, "Do should not be called anymore")
+
+	res = s.OnMessage(Message{From: User{ID: 2, Username: "testuser2"}, ID: 2, Text: "Hello"})
+	assert.Equal(t, Response{}, res)
+	assert.Len(t, mockedHTTPClient.DoCalls(), 2, "Do should be called once more")
+}

--- a/app/main.go
+++ b/app/main.go
@@ -49,7 +49,7 @@ var opts struct {
 	SpamFilter struct {
 		Enabled bool          `long:"enabled" env:"ENABLED" description:"enable spam filter"`
 		API     string        `long:"api" env:"CAS_API" default:"https://api.cas.chat" description:"CAS API"`
-		TimeOut time.Duration `long:"timeout" env:"TIMEOUT" default:"5s" description:"CAS timeout in seconds"`
+		TimeOut time.Duration `long:"timeout" env:"TIMEOUT" default:"5s" description:"CAS timeout"`
 		Dry     bool          `long:"dry" env:"DRY" description:"dry mode, no bans"`
 	} `group:"spam-filter" namespace:"spam-filter" env-namespace:"SPAM_FILTER"`
 
@@ -141,7 +141,8 @@ func main() {
 	}
 
 	if opts.SpamFilter.Enabled {
-		log.Printf("[INFO] spam filter enabled")
+		log.Printf("[INFO] spam filter enabled, api=%s, timeout=%s, dry=%v",
+			opts.SpamFilter.API, opts.SpamFilter.TimeOut, opts.SpamFilter.Dry)
 		httpCasClient := &http.Client{Timeout: opts.SpamFilter.TimeOut}
 		multiBot = append(multiBot, bot.NewSpamFilter(opts.SpamFilter.API, httpCasClient, opts.SpamFilter.Dry))
 	}

--- a/app/main.go
+++ b/app/main.go
@@ -142,8 +142,8 @@ func main() {
 
 	if opts.SpamFilter.Enabled {
 		log.Printf("[INFO] spam filter enabled")
-		httpClient := &http.Client{Timeout: opts.SpamFilter.TimeOut}
-		multiBot = append(multiBot, bot.NewSpamFilter(opts.SpamFilter.API, httpClient, opts.SpamFilter.Dry))
+		httpCasClient := &http.Client{Timeout: opts.SpamFilter.TimeOut}
+		multiBot = append(multiBot, bot.NewSpamFilter(opts.SpamFilter.API, httpCasClient, opts.SpamFilter.Dry))
 	}
 
 	if sb, err := bot.NewSys(opts.SysData); err == nil {


### PR DESCRIPTION
this PR adds a check via `https://api.cas.chat/check?user_id=<id>` API on a first message. If the user ID is passed, added to the approved list and won't run a check on that ID anymore

If the user is a spammer, it will be blocked permanently, and the message will be deleted. Dry mode won't remove message and won't ban, just reply with a warning.
