### PR TITLE
Remove newlines and spaces in spammer display names

### DIFF
--- a/app/bot/spam.go
+++ b/app/bot/spam.go
@@ -68,7 +68,7 @@ func (s *SpamFilter) OnMessage(msg Message) (response Response) {
 		return Response{} // don't check super users for spam
 	}
 
-	displayUsername := DisplayName(msg)
+	displayUsername := strings.TrimSpace(DisplayName(msg))
 	isEmojiSpam, _ := s.tooManyEmojis(msg.Text, maxEmojiAllowed)
 	if s.isSpamSimilarity(msg.Text) || isEmojiSpam || s.stopWords(msg.Text) || s.isCasSpam(msg.From.ID) {
 		log.Printf("[INFO] user %s detected as spammer, msg: %q", displayUsername, msg.Text)


### PR DESCRIPTION
It seems like spammers commonly use "\n" in their usernames, and the bot sends a two-line response ([screenshot_with_example_imgur](https://i.imgur.com/sqiz7xM.png)). 

There was a thought to change the "DisplayName()" function, but it's probably the correct way to leave it to output the "real" display name and clean it just before sending.
