### PR TITLE
Fix joke sources in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 | Команда                                   | Описание                                                                                                       |
 |-------------------------------------------|----------------------------------------------------------------------------------------------------------------|
 | `ping`, `пинг`                            | ответит `pong`, `понг`, см. [basic.data](https://github.com/radio-t/gitter-rt-bot/blob/master/data/basic.data) |
-| `анекдот!`, `анкедот!`, `joke!`, `chuck!` | расскажет анекдот с rzhunemogu.ru или icndb.com (нужен `MASHAPE_TOKEN`)                                        |
+| `анекдот!`, `анкедот!`, `joke!`, `chuck!` | расскажет анекдот с jokesrv.fermyon.app или chucknorris.io                                        |
 | `news!`, `новости!`                       | 5 последних [новостей для Радио-Т](https://news.radio-t.com)                                                   |
 | `so!`                                     | 1 вопрос со [Stackoverflow](https://stackoverflow.com/questions?tab=Active)                                    |
 | `?? <запрос>`, `/ddg <запрос>`            | поискать "<запрос>" на [DuckDuckGo](https://duckduckgo.com)                                                    |


### PR DESCRIPTION
Not sure about the `MASHAPE_TOKEN`, it seems that it is related to the DuckDuckGo search according to the info below and not to jokes APIs.