### PR TITLE
Fixes markdown parse error #127

### DIFF
--- a/app/events/telegram.go
+++ b/app/events/telegram.go
@@ -257,10 +257,10 @@ func (l *TelegramListener) sendBotResponse(resp bot.Response, chatID int64) erro
 
 	if err != nil {
 		// If it can't parse entities, try to send message without markdown parse mode
-		if strings.Contains(err.Error(), "Bad Request: can't parse entities:") {
+		if tbMsg.ParseMode == tbapi.ModeMarkdown && strings.Contains(err.Error(), "Bad Request: can't parse entities:") {
 			tbMsg.ParseMode = ""
+			res, err = l.TbAPI.Send(tbMsg)
 		}
-		res, err = l.TbAPI.Send(tbMsg)
 		if err != nil {
 			return fmt.Errorf("can't send message to telegram %q: %w", resp.Text, err)
 		}

--- a/app/events/telegram.go
+++ b/app/events/telegram.go
@@ -246,25 +246,8 @@ func (l *TelegramListener) sendBotResponse(resp bot.Response, chatID int64) erro
 	}
 
 	log.Printf("[DEBUG] bot response - %+v, pin: %t, reply-to:%d, parse-mode:%s", resp.Text, resp.Pin, resp.ReplyTo, resp.ParseMode)
-	tbMsg := tbapi.NewMessage(chatID, resp.Text)
-	tbMsg.ParseMode = tbapi.ModeMarkdown
-	if resp.ParseMode != "" {
-		tbMsg.ParseMode = resp.ParseMode
-	}
-	tbMsg.DisableWebPagePreview = !resp.Preview
-	tbMsg.ReplyToMessageID = resp.ReplyTo
-	res, err := l.TbAPI.Send(tbMsg)
 
-	if err != nil {
-		// If it can't parse entities, try to send message without markdown parse mode
-		if tbMsg.ParseMode == tbapi.ModeMarkdown && strings.Contains(err.Error(), "Bad Request: can't parse entities:") {
-			tbMsg.ParseMode = ""
-			res, err = l.TbAPI.Send(tbMsg)
-		}
-		if err != nil {
-			return fmt.Errorf("can't send message to telegram %q: %w", resp.Text, err)
-		}
-	}
+	res, err := l.sendMdWithFallback(resp, chatID)
 
 	l.saveBotMessage(&res, chatID)
 
@@ -283,6 +266,34 @@ func (l *TelegramListener) sendBotResponse(resp bot.Response, chatID int64) erro
 	}
 
 	return nil
+}
+
+// sendMdWithFallback sends message with markdown mode and fallback to plain text
+func (l *TelegramListener) sendMdWithFallback(resp bot.Response, chatID int64) (tbapi.Message, error) {
+	log.Printf("[DEBUG] sending message to telegram")
+	tbMsg := tbapi.NewMessage(chatID, resp.Text)
+	tbMsg.ParseMode = tbapi.ModeMarkdown
+	if resp.ParseMode != "" {
+		tbMsg.ParseMode = resp.ParseMode
+	}
+	tbMsg.DisableWebPagePreview = !resp.Preview
+	tbMsg.ReplyToMessageID = resp.ReplyTo
+	res, err := l.TbAPI.Send(tbMsg)
+
+	if err != nil {
+		// If it can't parse entities, try to send message as plain text
+		if tbMsg.ParseMode == tbapi.ModeMarkdown && strings.Contains(err.Error(), "Bad Request: can't parse entities:") {
+			log.Printf("[WARN] failed to send message as markdown, %v", err)
+			log.Printf("[DEBUG] sending message as plain text")
+			tbMsg.ParseMode = ""
+			res, err = l.TbAPI.Send(tbMsg)
+		}
+		if err != nil {
+			return res, fmt.Errorf("can't send message to telegram %q: %w", resp.Text, err)
+		}
+	}
+
+	return res, nil
 }
 
 // bans user or a channel

--- a/app/events/telegram.go
+++ b/app/events/telegram.go
@@ -249,6 +249,10 @@ func (l *TelegramListener) sendBotResponse(resp bot.Response, chatID int64) erro
 
 	res, err := l.sendMdWithFallback(resp, chatID)
 
+	if err != nil {
+		return err
+	}
+
 	l.saveBotMessage(&res, chatID)
 
 	if resp.Pin {

--- a/app/events/telegram.go
+++ b/app/events/telegram.go
@@ -287,8 +287,7 @@ func (l *TelegramListener) sendMdWithFallback(resp bot.Response, chatID int64) (
 	if err != nil {
 		// If it can't parse entities, try to send message as plain text
 		if tbMsg.ParseMode == tbapi.ModeMarkdown && strings.Contains(err.Error(), "Bad Request: can't parse entities:") {
-			log.Printf("[WARN] failed to send message as markdown, %v", err)
-			log.Printf("[DEBUG] sending message as plain text")
+			log.Printf("[WARN] failed to send message as markdown, retrying as plain text. Error: %v", err)
 			tbMsg.ParseMode = ""
 			res, err = l.TbAPI.Send(tbMsg)
 		}


### PR DESCRIPTION
Try to send a message to telegram without parsemode markdown if it can't be parsed correctly.