### PR TITLE
Replace uReadability with markdown.new for content extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cover.out
 .env
 
 cache_openai.json
+super-bot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,33 +1,84 @@
-# Super-Bot Development Guide
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Build Commands
-- Build: `make build` or `go build -v -o super-bot ./app`
-- Test all: `make test` or `go test ./app/...`
-- Test single: `go test -v ./app/bot/path/to/specific_test.go`
-- Run tests with coverage: `go test ./app/... -coverprofile cover.out`
+
+- Build: `make build` or `cd app && go build -v`
+- Test all: `make test` or `go test ./app/... -coverprofile cover.out`
+- Test single package: `go test -v ./app/bot/` or `go test -v -run TestFuncName ./app/bot/`
 - Lint: `make lint` or `golangci-lint run ./app/...`
-- Run locally: `make run ARGS="--super=username --dbg"`
-- Generate mocks: `make generate`
+- Generate mocks: `make generate` or `go generate ./app/...`
+- Run locally: `make run ARGS="--super=username --dbg"` (requires `TELEGRAM_TOKEN` and `TELEGRAM_GROUP` env vars)
 
-## Code Style Guidelines
-- Go version: 1.21+
-- Format with gofmt/goimports
-- Error handling: check all errors, log with proper level [ERROR], [INFO], [DEBUG]
-- Use lgr package for structured logging
-- Testing: use testify for assertions and mocks
-- Config: use go-flags for CLI args and env vars with proper descriptions
-- Imports: group standard lib, 3rd party, and internal packages
-- Naming: use CamelCase for exported, camelCase for private
-- Comments: all comments inside functions must be lowercase
+## Architecture
 
-## Clean Code Principles
-- Follow interfaces for testability (see bot.Interface)
-- Use Context for cancellation
-- Unit test coverage should be maintained
-- Error messages should be descriptive and actionable
+This is a **Telegram bot for the Radio-T podcast** (`github.com/radio-t/super-bot`). Go 1.24.
+
+### Core Pattern: Plugin Bot Architecture
+
+All bots implement the `bot.Interface` (defined in `app/bot/bot.go`):
+
+```go
+type Interface interface {
+    OnMessage(msg Message) Response
+    ReactOn() []string   // trigger keywords
+    Help() string
+}
+```
+
+`MultiBot` aggregates all bots and dispatches messages **in parallel** (4 goroutines via `syncs.SizedGroup`). Responses are collected, merged, and **sorted alphabetically** — multiple bots can respond to the same message.
+
+### Message Flow
+
+```
+Telegram Group → TelegramListener.Do() (app/events/telegram.go)
+  → Transform tbapi.Message → bot.Message
+  → Check terminators (rate limiting / ban enforcement)
+  → MultiBot.OnMessage() (parallel dispatch to all bots)
+  → Send response back to Telegram (markdown with plain-text fallback)
+  → Log to reporter (JSON lines, one file per day in logs/)
+  → Execute response flags (ban, pin, unpin, delete)
+```
+
+External messages also arrive via **RTJC TCP listener** (`app/events/rtjc.go`) on port 18001 from news.radio-t.com.
+
+### Key Components
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| Entry point | `app/main.go` | Config parsing, wiring, startup |
+| Bot interface & MultiBot | `app/bot/bot.go` | Plugin interface + parallel dispatch |
+| Individual bots | `app/bot/*.go` | WTF, News, Anecdote, DuckDuckGo, When, Banhammer, Sys, Spam, etc. |
+| OpenAI/ChatGPT bot | `app/bot/openai/` | Chat with history context, summarizer, Remark42/uReadability integration |
+| Telegram listener | `app/events/telegram.go` | Main event loop, message routing, ban enforcement |
+| RTJC listener | `app/events/rtjc.go` | TCP listener for external message submissions |
+| Terminators | `app/events/terminator.go` | Three rate limiters: all-activity, bot-activity, overall-bot-activity |
+| SuperUser | `app/events/superuser.go` | Moderator privilege checks (exempt from rate limiting) |
+| Reporter/Logger | `app/reporter/reporter.go` | Non-blocking JSON message persistence, batched writes |
+| HTML Exporter | `app/reporter/export.go` | Generates HTML chat reports from daily logs |
+| Data files | `data/` | `basic.data` (trigger→response pairs), `say.data` (random quotes), `whatsthetime.data`, `logs.html` template |
+
+### Important Design Decisions
+
+- **No database** — all persistence is file-based JSON lines (one file per day: `logs/YYYYMMDD.log`)
+- **Channel banning** — detects messages from channels (ID 136817688) and permanently bans the channel, not the fake user
+- **Markdown fallback** — if Telegram rejects markdown, automatically resends as plain text
+- **SuperUsers** are exempt from rate limiting and spam checks but not from admin bans
+- **OpenAI bot** maintains a rolling message history (default 5) for context-aware responses; has separate modes for direct queries (`chat!/gpt!/ai!`) and probabilistic auto-responses
+- **Export mode** — passing `--export-num` flag runs HTML report generation instead of the bot listener
+
+## Code Style
+
+- Logging: use `lgr` package with level prefixes `[ERROR]`, `[INFO]`, `[DEBUG]`
+- Config: `go-flags` with CLI args and env vars (e.g., `--telegram-token` / `TELEGRAM_TOKEN`)
+- Testing: `testify` for assertions, `moq` for mock generation (`//go:generate moq ...`)
+- Comments inside functions must be lowercase
+- HTTP clients use retry middleware via `go-pkgz/requester` (10 attempts, 5s intervals) for external API calls
 
 ## OpenAI Bot Implementation Notes
+
 - The OpenAI bot maintains message history to track conversation context
-- Direct queries (with chat!/gpt!/ai!/чат! prefixes) use history while focusing on the current message
+- Direct queries (with `chat!/gpt!/ai!/чат!` prefixes) use history while focusing on the current message
 - The `chatGPTRequestWithHistoryAndFocus` function balances context awareness with response relevance
 - History size is configurable via the `--history-size` flag (default: 5 messages)

--- a/app/bot/openai/mdnew.go
+++ b/app/bot/openai/mdnew.go
@@ -1,0 +1,140 @@
+package openai
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// MarkdownNewClient extracts page content using markdown.new service.
+// It implements the uKeeperGetter interface as a drop-in replacement for UKeeperClient.
+type MarkdownNewClient struct {
+	Client *http.Client
+	API    string // base URL, e.g. "https://markdown.new"
+}
+
+// Get returns title and markdown content for the given link using markdown.new.
+// markdown.new response format:
+//
+//	Title: <title>
+//	URL Source: <url>
+//	Markdown Content:
+//	---
+//	title: <title>
+//	---
+//	<markdown body>
+func (m MarkdownNewClient) Get(link string) (title, content string, err error) {
+	reqURL := strings.TrimSuffix(m.API, "/") + "/" + link
+	resp, err := m.Client.Get(reqURL)
+	if err != nil {
+		return "", "", fmt.Errorf("can't get markdown for %s: %w", link, err)
+	}
+	defer resp.Body.Close() //nolint
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("can't get markdown for %s: status %d", link, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", fmt.Errorf("can't read markdown response for %s: %w", link, err)
+	}
+
+	title, content = parseMarkdownNewResponse(string(body))
+	if content == "" {
+		return "", "", fmt.Errorf("empty content from markdown.new for %s", link)
+	}
+
+	return title, content, nil
+}
+
+// parseMarkdownNewResponse parses the markdown.new response format.
+// It extracts title from the "Title:" header line, and markdown body from after "Markdown Content:".
+// If "Markdown Content:" section contains YAML frontmatter, it is stripped from the body.
+// Falls back to frontmatter title or first # heading if "Title:" header is missing.
+func parseMarkdownNewResponse(raw string) (title, body string) {
+	raw = strings.TrimSpace(raw)
+
+	// look for "Title:" header at the top
+	headerTitle := extractHeaderField(raw, "Title:")
+
+	// look for "Markdown Content:" separator
+	mdContent := raw
+	if idx := strings.Index(raw, "Markdown Content:"); idx >= 0 {
+		mdContent = strings.TrimSpace(raw[idx+len("Markdown Content:"):])
+	}
+
+	// strip YAML frontmatter from markdown content if present
+	fmTitle, mdBody := stripFrontmatter(mdContent)
+	if mdBody != "" {
+		mdContent = mdBody
+	}
+
+	// title priority: header "Title:" > frontmatter title > first # heading
+	title = headerTitle
+	if title == "" {
+		title = fmTitle
+	}
+	if title == "" {
+		title = extractHeadingTitle(mdContent)
+	}
+
+	return title, mdContent
+}
+
+// extractHeaderField extracts value from a "Key: value" line at the beginning of text
+func extractHeaderField(text, key string) string {
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, key) {
+			return strings.TrimSpace(strings.TrimPrefix(line, key))
+		}
+		if line == "" {
+			continue
+		}
+		// stop at first non-header, non-empty line that isn't our key
+		if !strings.Contains(line, ":") {
+			break
+		}
+	}
+	return ""
+}
+
+// stripFrontmatter removes YAML frontmatter (---\n...\n---) and returns frontmatter title + body
+func stripFrontmatter(text string) (title, body string) {
+	text = strings.TrimSpace(text)
+	if !strings.HasPrefix(text, "---") {
+		return "", text
+	}
+
+	end := strings.Index(text[3:], "\n---")
+	if end < 0 {
+		return "", text
+	}
+
+	frontmatter := text[3 : 3+end]
+	body = strings.TrimSpace(text[3+end+4:])
+
+	for _, line := range strings.Split(frontmatter, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "title:") {
+			title = strings.TrimSpace(strings.TrimPrefix(line, "title:"))
+			title = strings.Trim(title, `"'`)
+			break
+		}
+	}
+
+	return title, body
+}
+
+// extractHeadingTitle extracts title from first # heading in markdown
+func extractHeadingTitle(md string) string {
+	for _, line := range strings.Split(md, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "# ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "# "))
+		}
+	}
+	return ""
+}

--- a/app/bot/openai/mdnew_test.go
+++ b/app/bot/openai/mdnew_test.go
@@ -1,0 +1,191 @@
+package openai
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarkdownNewClient_Get(t *testing.T) {
+	tbl := []struct {
+		name            string
+		response        string
+		statusCode      int
+		expectedTitle   string
+		expectedContent string
+		err             string
+	}{
+		{
+			name: "real markdown.new format with frontmatter",
+			response: "Title: Test Article\n\nURL Source: https://example.com\n\nMarkdown Content:\n" +
+				"---\ntitle: Test Article\ndescription: some desc\n---\n\n# Test Article\n\nSome content here.",
+			statusCode:      http.StatusOK,
+			expectedTitle:   "Test Article",
+			expectedContent: "# Test Article\n\nSome content here.",
+		},
+		{
+			name: "markdown.new format without frontmatter",
+			response: "Title: Page Title\n\nURL Source: https://example.com\n\nMarkdown Content:\n" +
+				"# Page Title\n\nBody text.",
+			statusCode:      http.StatusOK,
+			expectedTitle:   "Page Title",
+			expectedContent: "# Page Title\n\nBody text.",
+		},
+		{
+			name:            "plain markdown without headers",
+			response:        "# Direct Heading\n\nParagraph content.",
+			statusCode:      http.StatusOK,
+			expectedTitle:   "Direct Heading",
+			expectedContent: "# Direct Heading\n\nParagraph content.",
+		},
+		{
+			name: "frontmatter title differs from header title",
+			response: "Title: Header Title\n\nMarkdown Content:\n" +
+				"---\ntitle: FM Title\n---\n\nBody.",
+			statusCode:      http.StatusOK,
+			expectedTitle:   "Header Title",
+			expectedContent: "Body.",
+		},
+		{
+			name:       "completely empty response",
+			response:   "",
+			statusCode: http.StatusOK,
+			err:        "empty content from markdown.new for http://example.com",
+		},
+		{
+			name:       "server error",
+			response:   "error",
+			statusCode: http.StatusInternalServerError,
+			err:        "can't get markdown for http://example.com: status 500",
+		},
+	}
+
+	for _, tt := range tbl {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/http://example.com", r.URL.Path)
+				w.WriteHeader(tt.statusCode)
+				_, err := w.Write([]byte(tt.response))
+				require.NoError(t, err)
+			}))
+			defer ts.Close()
+
+			mc := MarkdownNewClient{
+				API:    ts.URL,
+				Client: ts.Client(),
+			}
+
+			title, content, err := mc.Get("http://example.com")
+			if tt.err == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedTitle, title)
+				assert.Equal(t, tt.expectedContent, content)
+			} else {
+				require.Error(t, err)
+				assert.Equal(t, tt.err, err.Error())
+			}
+		})
+	}
+}
+
+func TestParseMarkdownNewResponse(t *testing.T) {
+	tbl := []struct {
+		name          string
+		input         string
+		expectedTitle string
+		expectedBody  string
+	}{
+		{
+			name: "full markdown.new response",
+			input: "Title: My Article\n\nURL Source: https://example.com\n\nMarkdown Content:\n" +
+				"---\ntitle: My Article\ndescription: desc\nimage: img.png\n---\n\n# My Article\n\nContent here.",
+			expectedTitle: "My Article",
+			expectedBody:  "# My Article\n\nContent here.",
+		},
+		{
+			name: "quoted frontmatter title, no header title",
+			input: "Markdown Content:\n---\ntitle: \"Quoted Title\"\n---\n\nBody text.",
+			expectedTitle: "Quoted Title",
+			expectedBody:  "Body text.",
+		},
+		{
+			name:          "plain markdown, no headers at all",
+			input:         "# Direct Heading\n\nParagraph.",
+			expectedTitle: "Direct Heading",
+			expectedBody:  "# Direct Heading\n\nParagraph.",
+		},
+		{
+			name:          "no title anywhere",
+			input:         "Markdown Content:\nJust plain text without any structure.",
+			expectedTitle: "",
+			expectedBody:  "Just plain text without any structure.",
+		},
+		{
+			name: "header title takes precedence over frontmatter",
+			input: "Title: From Header\n\nMarkdown Content:\n" +
+				"---\ntitle: From Frontmatter\n---\n\nBody.",
+			expectedTitle: "From Header",
+			expectedBody:  "Body.",
+		},
+		{
+			name: "single-quoted frontmatter title",
+			input: "Markdown Content:\n---\ntitle: 'Single Quoted'\n---\n\nBody.",
+			expectedTitle: "Single Quoted",
+			expectedBody:  "Body.",
+		},
+	}
+
+	for _, tt := range tbl {
+		t.Run(tt.name, func(t *testing.T) {
+			title, body := parseMarkdownNewResponse(tt.input)
+			assert.Equal(t, tt.expectedTitle, title)
+			assert.Equal(t, tt.expectedBody, body)
+		})
+	}
+}
+
+func TestStripFrontmatter(t *testing.T) {
+	tbl := []struct {
+		name          string
+		input         string
+		expectedTitle string
+		expectedBody  string
+	}{
+		{
+			name:          "with frontmatter",
+			input:         "---\ntitle: FM Title\nauthor: test\n---\nBody content",
+			expectedTitle: "FM Title",
+			expectedBody:  "Body content",
+		},
+		{
+			name:          "no frontmatter",
+			input:         "Just text",
+			expectedTitle: "",
+			expectedBody:  "Just text",
+		},
+		{
+			name:          "frontmatter without title",
+			input:         "---\nauthor: test\n---\nBody",
+			expectedTitle: "",
+			expectedBody:  "Body",
+		},
+		{
+			name:          "incomplete frontmatter (no closing)",
+			input:         "---\ntitle: Broken\nBody text",
+			expectedTitle: "",
+			expectedBody:  "---\ntitle: Broken\nBody text",
+		},
+	}
+
+	for _, tt := range tbl {
+		t.Run(tt.name, func(t *testing.T) {
+			title, body := stripFrontmatter(tt.input)
+			assert.Equal(t, tt.expectedTitle, title)
+			assert.Equal(t, tt.expectedBody, body)
+		})
+	}
+}

--- a/app/main.go
+++ b/app/main.go
@@ -75,8 +75,7 @@ var opts struct {
 	} `group:"openai" namespace:"openai" env-namespace:"OPENAI"`
 
 	RemarkAPI            string `long:"remark-api" env:"REMARK_API" default:"https://remark42.radio-t.com/api/v1/find" description:"Remark API"`
-	UreadabilityAPI      string `long:"ur-api" env:"UREADABILITY_API" default:"https://ureadability.radio-t.com/api/content/v1/parser" description:"uReadability API"`
-	UreadabilityToken    string `long:"ur-token" env:"UREADABILITY_TOKEN" default:"undefined" description:"uReadability token"`
+	MarkdownNewAPI       string `long:"mdnew-api" env:"MDNEW_API" default:"https://markdown.new" description:"markdown.new API for content extraction"`
 	SummarizerThreadsNum int    `long:"summarizer-threads" env:"SUMMARIZER_THREADS" default:"5" description:"Number of threads in summarizer"`
 
 	RtjcParams struct {
@@ -225,16 +224,15 @@ func main() {
 		API:    opts.RemarkAPI,
 	}
 
-	uKeeperClient := openai.UKeeperClient{
+	mdNewClient := openai.MarkdownNewClient{
 		Client: httpClient,
-		API:    opts.UreadabilityAPI,
-		Token:  opts.UreadabilityToken,
+		API:    opts.MarkdownNewAPI,
 	}
 
 	summarizer := openai.NewSummarizer(
 		openAIBot,
 		remarkClient,
-		uKeeperClient,
+		mdNewClient,
 		opts.SummarizerThreadsNum,
 		opts.Dbg,
 	)


### PR DESCRIPTION
## Summary

- **Problem**: uReadability (`ureadability.radio-t.com`) often fails to extract content from websites that block server-side requests or require JS rendering, resulting in error messages or stubs being posted as summaries in the chat.
- **Solution**: Replace uReadability with [markdown.new](https://markdown.new/) — a Cloudflare-powered service with a three-tier fallback pipeline (content negotiation → Workers AI → browser rendering) that handles JS-heavy and bot-protected sites reliably.
- **Changes**:
  - New `MarkdownNewClient` in `app/bot/openai/mdnew.go` implementing the existing `uKeeperGetter` interface (drop-in replacement)
  - Parses markdown.new response format: `Title:` header line + YAML frontmatter + markdown body
  - Replaced `UKeeperClient` wiring in `main.go`; removed `--ur-api`/`--ur-token` flags, added `--mdnew-api` (default: `https://markdown.new`, env: `MDNEW_API`)

## Deployment notes

- Remove `UREADABILITY_API` and `UREADABILITY_TOKEN` env vars from deployment config
- Optionally set `MDNEW_API` if a different endpoint is needed (default works out of the box, no auth required)

## Test plan

- [x] Unit tests for `MarkdownNewClient.Get()` with mock HTTP server
- [x] Unit tests for response parser (`parseMarkdownNewResponse`, `stripFrontmatter`)
- [x] Verified against real markdown.new with `https://openai.com/index/introducing-gpt-5-4/` — title and content extracted correctly (31K chars of clean markdown)
- [x] All existing tests pass (`go test ./app/...`)
- [ ] End-to-end: run bot locally, send RTJC message with ⚠️ + link, verify summary appears in chat

🤖 Generated with [Claude Code](https://claude.ai/claude-code)