### PR TITLE
Add explicit token permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: build
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
 
   build:
@@ -15,6 +19,8 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: build and test
       run: |


### PR DESCRIPTION
Previously, the workflow declared no `permissions` block, so `GITHUB_TOKEN` inherited the repository default, which grants write access across every scope unless the repository or organisation setting narrows it. Nothing in the job writes through that token: coverage is submitted to Coveralls, images are pushed to Docker Hub with separate credentials, and the deployment step calls an external endpoint with `UPDATER_KEY`. A top-level `contents: read` covers all of it, and it is the explicit scope CodeQL asks for on workflows that declare none.

The checkout step also gets `persist-credentials: false`, so the token is no longer written into `.git/config`, where later steps such as `go install ...@latest` and `docker build` would have it in reach. Nothing in the workflow performs a git operation after checkout, so removing the persisted credentials costs nothing.