### PR TITLE
Bump CI actions to current majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ jobs:
     steps:
 
     - name: set up go 1.25
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version: "1.25"
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: build and test
       run: |
@@ -25,7 +25,7 @@ jobs:
         TZ: "America/Chicago"
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@v9
       with:
         version: v2.12.2
 


### PR DESCRIPTION
Moves the workflow to the current majors: `actions/setup-go` v5 to v7, `actions/checkout` v4 to v7, and `golangci/golangci-lint-action` v7 to v9.

The v7 majors of the two `actions/*` are ESM and Node 24 runtime migrations, and `ubuntu-latest` already runs a new enough runner for Node 24. `checkout` v7 additionally blocks fork pull request checkout for `pull_request_target` and `workflow_run`, neither of which this workflow uses. `golangci-lint-action` v8 requires golangci-lint v2.1.0 or newer, which the pinned v2.12.2 satisfies, and its switch to absolute paths only applies when `working-directory` is set, which it is not here.

No inputs changed, so the rest of the workflow is untouched.