### PR TITLE
Apply go fix

### DIFF
--- a/app/bot/banhammer.go
+++ b/app/bot/banhammer.go
@@ -111,9 +111,9 @@ func (b *Banhammer) cleanup() {
 func (b *Banhammer) parse(text string) (react bool, cmd, name string) {
 
 	for _, prefix := range b.ReactOn() {
-		if strings.HasPrefix(text, prefix) {
+		if after, ok := strings.CutPrefix(text, prefix); ok {
 			return true, strings.TrimSuffix(prefix, "!"),
-				strings.ReplaceAll(strings.TrimSpace(strings.TrimPrefix(text, prefix)), " ", "+")
+				strings.ReplaceAll(strings.TrimSpace(after), " ", "+")
 		}
 	}
 	return false, "", ""

--- a/app/bot/bot.go
+++ b/app/bot/bot.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -71,7 +71,7 @@ type SenderChat struct {
 type Message struct {
 	ID         int
 	From       User
-	SenderChat SenderChat `json:"sender_chat,omitempty"`
+	SenderChat SenderChat `json:"sender_chat"`
 	ChatID     int64
 	Sent       time.Time
 	HTML       string    `json:",omitempty"`
@@ -82,8 +82,8 @@ type Message struct {
 		From       User
 		Text       string `json:",omitempty"`
 		Sent       time.Time
-		SenderChat SenderChat `json:"sender_chat,omitempty"`
-	} `json:",omitempty"`
+		SenderChat SenderChat `json:"sender_chat"`
+	}
 }
 
 // Entity represents one special entity in a text message.
@@ -200,9 +200,7 @@ func (b MultiBot) OnMessage(msg Message) (response Response) {
 		lines = append(lines, r)
 	}
 
-	sort.Slice(lines, func(i, j int) bool {
-		return lines[i] < lines[j]
-	})
+	slices.Sort(lines)
 
 	if len(lines) > 0 {
 		log.Printf("[DEBUG] answers %d, send %v", len(lines), len(lines) > 0)

--- a/app/bot/broadcast_status_test.go
+++ b/app/bot/broadcast_status_test.go
@@ -39,8 +39,7 @@ func TestBroadcast_OnMessage(t *testing.T) {
 
 // Kind of integration test to check all workflow
 func TestBroadcast_StatusTransitions(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	status := true // hold here ping status
 	statusMx := sync.Mutex{}
@@ -93,8 +92,7 @@ func TestBroadcast_StatusTransitions(t *testing.T) {
 }
 
 func TestBroadcast_StatusOffToOn(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -111,8 +109,7 @@ func TestBroadcast_StatusOffToOn(t *testing.T) {
 }
 
 func TestBroadcast_StatusOffToOff(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -130,8 +127,7 @@ func TestBroadcast_StatusOffToOff(t *testing.T) {
 }
 
 func TestBroadcast_StatusOnToOffNoDeadline(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -150,8 +146,7 @@ func TestBroadcast_StatusOnToOffNoDeadline(t *testing.T) {
 }
 
 func TestBroadcast_StatusOnToOffWithDeadline(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -198,8 +193,7 @@ func TestBroadcast_OnMessageReturnsReplyOnChange(t *testing.T) {
 }
 
 func TestBroadcast_PingReturnsTrueOn200Status(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -210,8 +204,7 @@ func TestBroadcast_PingReturnsTrueOn200Status(t *testing.T) {
 }
 
 func TestBroadcast_PingReturnsFalseOnNot200Status(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -222,8 +215,7 @@ func TestBroadcast_PingReturnsFalseOnNot200Status(t *testing.T) {
 }
 
 func TestBroadcast_PingReturnsFalseOnUnableToDoRequest(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	require.False(t, ping(ctx, http.Client{}, "http://localhost:9873"))
 }
 

--- a/app/bot/duckduckgo.go
+++ b/app/bot/duckduckgo.go
@@ -81,8 +81,8 @@ func (d *Duck) OnMessage(msg Message) (response Response) {
 func (d *Duck) request(text string) (react bool, reqText string) {
 
 	for _, prefix := range d.ReactOn() {
-		if strings.HasPrefix(text, prefix) {
-			return true, strings.ReplaceAll(strings.TrimSpace(strings.TrimPrefix(text, prefix)), " ", "+")
+		if after, ok := strings.CutPrefix(text, prefix); ok {
+			return true, strings.ReplaceAll(strings.TrimSpace(after), " ", "+")
 		}
 	}
 	return false, ""

--- a/app/bot/openai/openaihistory_test.go
+++ b/app/bot/openai/openaihistory_test.go
@@ -40,7 +40,7 @@ func Test_LimitedMessageHistory(t *testing.T) {
 			}
 
 			// add messages to the storage. This should remove the oldest messages
-			for j := 0; j < 3; j++ {
+			for j := range 3 {
 				newID := tt.limit + j
 				history.Add(bot.Message{
 					ID:   newID,

--- a/app/bot/podcasts.go
+++ b/app/bot/podcasts.go
@@ -100,7 +100,7 @@ func (p *Podcasts) makeBotResponse(sr []siteAPIResp, reqText string) string {
 		return fmt.Sprintf("ничего не нашел на запрос %q", reqText)
 	}
 
-	var res string
+	var res strings.Builder
 	for _, s := range sr {
 		nls := p.notesWithLinks(s)
 		nlsStr := ""
@@ -118,12 +118,12 @@ func (p *Podcasts) makeBotResponse(sr []siteAPIResp, reqText string) string {
 		}
 
 		if nlsStr != "" {
-			res += fmt.Sprintf("[Радио-Т #%d](%s) _%s_\n", s.ShowNum, s.URL, s.Date.Format("02 Jan 06"))
-			res += nlsStr
-			res += "\n"
+			fmt.Fprintf(&res, "[Радио-Т #%d](%s) _%s_\n", s.ShowNum, s.URL, s.Date.Format("02 Jan 06"))
+			res.WriteString(nlsStr)
+			res.WriteString("\n")
 		}
 	}
-	return res
+	return res.String()
 }
 
 type noteWithLink struct {
@@ -139,7 +139,7 @@ func (p *Podcasts) notesWithLinks(s siteAPIResp) (res []noteWithLink) {
 
 	// show notes may start with multiple \n, strip them all
 	showNotes := s.ShowNotes
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		showNotes = strings.TrimPrefix(showNotes, "\n")
 	}
 
@@ -164,8 +164,8 @@ func (p *Podcasts) notesWithLinks(s siteAPIResp) (res []noteWithLink) {
 func (p *Podcasts) request(text string) (react bool, reqText string) {
 
 	for _, prefix := range p.ReactOn() {
-		if strings.HasPrefix(text, prefix) {
-			return true, strings.ReplaceAll(strings.TrimSpace(strings.TrimPrefix(text, prefix)), " ", "+")
+		if after, ok := strings.CutPrefix(text, prefix); ok {
+			return true, strings.ReplaceAll(strings.TrimSpace(after), " ", "+")
 		}
 	}
 	return false, ""

--- a/app/bot/preppost_test.go
+++ b/app/bot/preppost_test.go
@@ -85,7 +85,7 @@ func TestPrepPost_checkDuration(t *testing.T) {
 	}}
 	pp := NewPrepPost(mockHTTP, "http://example.com", time.Millisecond*50)
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		pp.OnMessage(Message{})
 		time.Sleep(6 * time.Millisecond)
 	}

--- a/app/bot/spam.go
+++ b/app/bot/spam.go
@@ -206,8 +206,8 @@ func (s *SpamFilter) tokenize(inp string) map[string]int {
 	}
 
 	tokenFrequency := make(map[string]int)
-	tokens := strings.Fields(inp)
-	for _, token := range tokens {
+	tokens := strings.FieldsSeq(inp)
+	for token := range tokens {
 		if isExcludedToken(token) {
 			continue
 		}

--- a/app/bot/whatsthetime.go
+++ b/app/bot/whatsthetime.go
@@ -65,16 +65,16 @@ func (w *WhatsTheTime) OnMessage(msg Message) (response Response) {
 }
 
 func buildResponseText(now time.Time, hosts []Host) string {
-	responseString := ""
+	var responseString strings.Builder
 	for _, host := range hosts {
 		location, err := time.LoadLocation(host.Timezone)
 		if err != nil {
 			log.Printf("[DEBUG] can't load location for %s: %s", host.Timezone, err)
 			continue
 		}
-		responseString += fmt.Sprintf("У %s сейчас %s\n", host.Name, now.In(location).Format("15:04"))
+		fmt.Fprintf(&responseString, "У %s сейчас %s\n", host.Name, now.In(location).Format("15:04"))
 	}
-	return responseString
+	return responseString.String()
 }
 
 // ReactOn returns reaction keys

--- a/app/reporter/export.go
+++ b/app/reporter/export.go
@@ -308,7 +308,7 @@ func format(text string, entities *[]bot.Entity) (out template.HTML) {
 	}
 
 	runes := []rune(text)
-	result := ""
+	var result strings.Builder
 	pos := 0
 
 	for _, entity := range *entities {
@@ -326,19 +326,19 @@ func format(text string, entities *[]bot.Entity) (out template.HTML) {
 			continue
 		}
 
-		result += html.EscapeString(string(runes[pos:entity.Offset])) +
+		result.WriteString(html.EscapeString(string(runes[pos:entity.Offset])) +
 			before +
 			html.EscapeString(string(runes[entity.Offset:entity.Offset+entity.Length])) +
-			after
+			after)
 
 		pos = entity.Offset + entity.Length
 	}
 
 	if len(runes) > pos {
-		result += html.EscapeString(string(runes[pos:]))
+		result.WriteString(html.EscapeString(string(runes[pos:])))
 	}
 
-	return template.HTML(strings.ReplaceAll(result, "\n", "<br>")) // nolint
+	return template.HTML(strings.ReplaceAll(result.String(), "\n", "<br>")) // nolint
 }
 
 // getDecoration returns a pair of HTML tags (decorations) for Telegram Entity


### PR DESCRIPTION
Output of `go fix ./...` on Go 1.26, where the command now runs the modernizer analysers. It rewrites `strings.HasPrefix` and `strings.TrimPrefix` pairs into `strings.CutPrefix`, `sort.Slice` into `slices.Sort`, counted loops into `for range n`, `strings.Fields` into `strings.FieldsSeq`, string accumulation into `strings.Builder`, and the per-test `context.WithCancel` pairs into `t.Context()`.

It also drops `omitempty` from the two struct-typed fields of `bot.Message`. The option has never had an effect there: encoding/json treats only false, 0, nil pointers, nil interfaces and empty arrays, slices, maps and strings as empty, so a struct is always encoded. The marshalled form of the message log written in `app/reporter/reporter.go` and read back in `app/reporter/export.go` is byte for byte the same, and existing logs still parse. The alternative rewrite `go fix` offers here, replacing `omitempty` with `omitzero`, would change behaviour and is deliberately not applied.

The `strings.Builder` rewrites left two `WriteString(fmt.Sprintf(...))` calls that staticcheck reports as QF1012, so those are written as `fmt.Fprintf` instead. Tests and golangci-lint are clean on the branch.